### PR TITLE
MRC-205: make configuration tuneable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,46 @@ which are out of our control (see the helper `docker_client` in `docker_helpers.
 
 ## Configuration
 
-Configuration is a work in progress and will change as the tool progresses.  See [`config/complete/orderly-web.yml`] for an annotated configuration.
+Configuration is a work in progress and will change as the tool progresses.  See [`config/complete/orderly-web.yml`] for an annotated configuration that covers all the options.
+
+### Modified versions of configurations
+
+It is possible to create sub-configurations that adapt a configuration.  To do this, create a base configuration with shared options and save that as `orderly-web.yml`.  Then, within the same directory, create secondary yml files (named however you want) that override options.  For example if you have an `orderly-web.yml` that contains
+
+```yaml
+web:
+  port: 443
+  name: OrderlyWeb
+  dev_mode: false
+```
+
+(among other options), you could create a yaml file called `testing.yml` (in the same directory) that contains
+
+```yaml
+web:
+  port: 8000
+  dev_mode: true
+```
+
+When run with
+
+```
+orderly-web path --extra testing.yml
+```
+
+the options in `testing.yml` will override the base configuration.  The options that are not mentioned in the `testing.yml` are left unmodified (i.e, in this case we end up with
+
+```yaml
+web:
+  port: 8000
+  name: OrderlyWeb
+  dev_mode: true
+```
+
+It is also possible to change options by passing individual changes through with the `--option` flag, for example:
+
+```
+orderly-web path --option web.port=8000 --option web.dev_mode=true
+```
+
+Use `.` to indicate a level of nesting and do not use spaces around the `=`; the right-hand-side is parsed as if it was yaml.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ This installs the package `orderly_web` for programmatic use, and a cli tool `or
 ```
 $ orderly-web --help
 Usage:
-  orderly-web start <path>
+  orderly-web start <path> [--extra=PATH] [--option=OPTION]... [--pull]
   orderly-web status <path>
-  orderly-web stop <path> [--volumes] [--network]
+  orderly-web stop <path> [--volumes] [--network] [--kill]
 
 Options:
-  --volumes   Remove volumes (WARNING: irreversible data loss)
-  --network   Remove network
+  --extra=PATH     Path, relative to <path>, of yml file of additional
+                   configuration
+  --option=OPTION  Additional configuration options, in the form key=value
+                   Use dots in key for hierarchical structure, e.g., a.b=value
+  --pull           Pull images before starting
+  --volumes        Remove volumes (WARNING: irreversible data loss)
+  --network        Remove network
+  --kill           Kill the containers (faster, but possible db corruption)
 ```
 
 Here `<path>` is the path to a directory that contains a configuration file `orderly-web.yml` (more options will follow in future versions).

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -1,7 +1,7 @@
 vault:
   ## Address of the vault server.  This should be a string if it is
   ## present.
-  url: ~
+  addr: ~
   auth:
     ## Authentication type - must be either "token" or the name of a
     ## supported authentication method.  These seem to be poorly

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -33,6 +33,14 @@ vault:
       token: ~
 
 ## Prefix for container names; we'll use {container_prefix}_(orderly,web)
+##
+## This is an important configuration option because it cannot be
+## overridden by a patch file or by passing options in.
+##
+## IMPORTANT: If you want to change the prefix, you should stop
+## OrderlyWeb, then change the prefix, then start it back up.
+## Otherwise OrderlyWeb will not take down the required containers
+## before starting back up.
 container_prefix: orderly_web
 
 ## The name of the docker network that containers will be attached to.

--- a/orderly_web/__init__.py
+++ b/orderly_web/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-from orderly_web.config import read_config
 from orderly_web.pull import pull
 from orderly_web.start import start
 from orderly_web.status import status
@@ -8,7 +7,6 @@ from orderly_web.stop import stop
 
 __all__ = [
     pull,
-    read_config,
     start,
     status,
     stop

--- a/orderly_web/cli.py
+++ b/orderly_web/cli.py
@@ -8,6 +8,7 @@ Options:
                    configuration
   --option=OPTION  Additional configuration options, in the form key=value
                    Use dots in key for hierarchical structure, e.g., a.b=value
+                   This argument may be repeated to provide multiple arguments
   --pull           Pull images before starting
   --volumes        Remove volumes (WARNING: irreversible data loss)
   --network        Remove network

--- a/orderly_web/cli.py
+++ b/orderly_web/cli.py
@@ -1,13 +1,17 @@
 """Usage:
-  orderly-web start <path> [--pull]
+  orderly-web start <path> [--extra=PATH] [--option=OPTION]... [--pull]
   orderly-web status <path>
   orderly-web stop <path> [--volumes] [--network] [--kill]
 
 Options:
-  --pull      Pull images before starting
-  --volumes   Remove volumes (WARNING: irreversible data loss)
-  --network   Remove network
-  --kill      Kill the containers (faster, but possible db corruption)
+  --extra=PATH     Path, relative to <path>, of yml file of additional
+                   configuration
+  --option=OPTION  Additional configuration options, in the form key=value
+                   Use dots in key for hierarchical structure, e.g., a.b=value
+  --pull           Pull images before starting
+  --volumes        Remove volumes (WARNING: irreversible data loss)
+  --network        Remove network
+  --kill           Kill the containers (faster, but possible db corruption)
 """
 
 import docopt
@@ -16,16 +20,40 @@ import orderly_web
 
 
 def main(argv=None):
+    target, args = parse_args(argv)
+    target(*args)
+
+
+def parse_args(argv):
     args = docopt.docopt(__doc__, argv)
     path = args["<path>"]
-
     if args["start"]:
+        extra = args["--extra"]
+        options = [string_to_dict(x) for x in args["--option"]]
         pull_images = args["--pull"]
-        orderly_web.start(path, pull_images)
+        target = orderly_web.start
+        args = (path, extra, options, pull_images)
     elif args["status"]:
+        target = orderly_web.status
+        args = (path, )
         print(orderly_web.status(path))
     elif args["stop"]:
-        network = args["--network"]
-        volumes = args["--volumes"]
-        kill = args["--kill"]
-        orderly_web.stop(path, network=network, volumes=volumes, kill=kill)
+        target = orderly_web.stop
+        args = (path, network, volumes, kill)
+    return target, args
+
+
+def string_to_dict(string):
+    """Convert a configuration option a.b.c=x to a dictionary
+{"a": {"b": "c": x}}"""
+    # Won't deal with dots embedded within quotes but that's ok as
+    # that should not be allowed generally.
+    try:
+        key, value = string.split("=")
+    except ValueError:
+        msg = "Invalid option '{}', expected option in form key=value".format(
+            string)
+        raise Exception(msg)
+    for k in reversed(key.split(".")):
+        value = {k: value}
+    return value

--- a/orderly_web/cli.py
+++ b/orderly_web/cli.py
@@ -1,7 +1,6 @@
 """Usage:
   orderly-web start <path> [--pull]
   orderly-web status <path>
-  orderly-web pull <path>
   orderly-web stop <path> [--volumes] [--network] [--kill]
 
 Options:
@@ -20,16 +19,13 @@ def main(argv=None):
     args = docopt.docopt(__doc__, argv)
     path = args["<path>"]
 
-    cfg = orderly_web.read_config(path)
     if args["start"]:
         pull_images = args["--pull"]
-        orderly_web.start(cfg, pull_images)
+        orderly_web.start(path, pull_images)
     elif args["status"]:
-        print(orderly_web.status(cfg))
-    elif args["pull"]:
-        orderly_web.pull(cfg)
+        print(orderly_web.status(path))
     elif args["stop"]:
         network = args["--network"]
         volumes = args["--volumes"]
         kill = args["--kill"]
-        orderly_web.stop(cfg, network=network, volumes=volumes, kill=kill)
+        orderly_web.stop(path, network=network, volumes=volumes, kill=kill)

--- a/orderly_web/cli.py
+++ b/orderly_web/cli.py
@@ -15,6 +15,7 @@ Options:
 """
 
 import docopt
+import yaml
 
 from orderly_web.status import print_status
 import orderly_web
@@ -55,6 +56,14 @@ def string_to_dict(string):
         msg = "Invalid option '{}', expected option in form key=value".format(
             string)
         raise Exception(msg)
+    value = yaml_atom_parse(value)
     for k in reversed(key.split(".")):
         value = {k: value}
     return value
+
+
+def yaml_atom_parse(x):
+    ret = yaml.load(x, Loader=yaml.Loader)
+    if type(ret) not in [bool, int, float, str]:
+        raise Exception("Invalid value '{}' - expected simple type".format(x))
+    return ret

--- a/orderly_web/cli.py
+++ b/orderly_web/cli.py
@@ -16,6 +16,7 @@ Options:
 
 import docopt
 
+from orderly_web.status import print_status
 import orderly_web
 
 
@@ -34,12 +35,12 @@ def parse_args(argv):
         target = orderly_web.start
         args = (path, extra, options, pull_images)
     elif args["status"]:
-        target = orderly_web.status
+        target = print_status
         args = (path, )
-        print(orderly_web.status(path))
     elif args["stop"]:
+        kill = args["--kill"]
         target = orderly_web.stop
-        args = (path, network, volumes, kill)
+        args = (path, kill)
     return target, args
 
 

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -19,6 +19,10 @@ def read_config(path, extra=None, options=None):
     return OrderlyWebConfig(dat)
 
 
+def fetch_config(path, error=False):
+    return read_config(path).fetch(error)
+
+
 def read_config_data(path, extra=None, options=None):
     dat = read_yaml("{}/orderly-web.yml".format(path))
     if extra:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -199,8 +199,8 @@ def config_data_update(path, data, extra=None, options=None):
 
 
 def config_check_additional(options):
-        if "container_prefix" in options:
-            raise Exception("'container_prefix' may not be modified")
+    if "container_prefix" in options:
+        raise Exception("'container_prefix' may not be modified")
 
 
 # Utility function for centralising control over pulling information

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -267,13 +267,3 @@ def combine(a, b):
         else:
             a[k] = v
     return a
-
-
-def string_to_dict(key, value):
-    """Convert a configuration key a.b.c with value x to a dictionary
-{"a": {"b": "c": x}}"""
-    # Won't deal with dots embedded within quotes but that's ok as
-    # that should not be allowed generally.
-    for k in reversed(key.split(".")):
-        value = {k: value}
-    return value

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -154,3 +154,21 @@ def config_image_reference(dat, path, name="name"):
     name = config_string(dat, path + [name])
     tag = config_string(dat, path + ["tag"])
     return DockerImageReference(repo, name, tag)
+
+
+def combine(*args):
+    """Combine a number of dictionaries recursively"""
+    a = args[0]
+    for b in args[1:]:
+        a = combine2(a, b)
+    return a
+
+
+def combine2(a, b):
+    """Combine exactly two dictionaries recursively"""
+    for k, v in b.items():
+        if k in a and type(a[k]) is dict:
+            combine(a[k], v)
+        else:
+            a[k] = v
+    return a

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -5,16 +5,18 @@ from orderly_web.docker_helpers import docker_client
 import orderly_web.vault as vault
 
 
-def read_config(path, extra=None):
-    dat = read_config_data(path, extra)
+def read_config(path, extra=None, options=None):
+    dat = read_config_data(path, extra, options)
     return OrderlyWebConfig(dat)
 
 
-def read_config_data(path, extra=None):
+def read_config_data(path, extra=None, options=None):
     dat = read_yaml("{}/orderly-web.yml".format(path))
     if extra:
         dat_extra = read_yaml("{}/{}.yml".format(path, extra))
         dat = combine(dat, dat_extra)
+    if options:
+        dat = combine(dat, options)
     return dat
 
 

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -5,11 +5,23 @@ from orderly_web.docker_helpers import docker_client
 import orderly_web.vault as vault
 
 
-def read_config(path):
-    path_yml = "{}/orderly-web.yml".format(path)
-    with open(path_yml, "r") as f:
-        dat = yaml.load(f, Loader=yaml.SafeLoader)
+def read_config(path, extra=None):
+    dat = read_config_data(path, extra)
     return OrderlyWebConfig(dat)
+
+
+def read_config_data(path, extra=None):
+    dat = read_yaml("{}/orderly-web.yml".format(path))
+    if extra:
+        dat_extra = read_yaml("{}/{}.yml".format(path, extra))
+        dat = combine(dat, dat_extra)
+    return dat
+
+
+def read_yaml(filename):
+    with open(filename, "r") as f:
+        dat = yaml.load(f, Loader=yaml.SafeLoader)
+    return dat
 
 
 class OrderlyWebConfig:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -172,3 +172,13 @@ def combine2(a, b):
         else:
             a[k] = v
     return a
+
+
+def string_to_dict(key, value):
+    """Convert a configuration key a.b.c with value x to a dictionary
+{"a": {"b": "c": x}}"""
+    # Won't deal with dots embedded within quotes but that's ok as
+    # that should not be allowed generally.
+    for k in reversed(key.split(".")):
+        value = {k: value}
+    return value

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -168,15 +168,7 @@ def config_image_reference(dat, path, name="name"):
     return DockerImageReference(repo, name, tag)
 
 
-def combine(*args):
-    """Combine a number of dictionaries recursively"""
-    a = args[0]
-    for b in args[1:]:
-        a = combine2(a, b)
-    return a
-
-
-def combine2(a, b):
+def combine(a, b):
     """Combine exactly two dictionaries recursively"""
     for k, v in b.items():
         if k in a and type(a[k]) is dict:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -52,8 +52,8 @@ def build_config(path, extra=None, options=None):
     return read_config(path).build(extra, options)
 
 
-def fetch_config(path, error=False):
-    return read_config(path).fetch(error)
+def fetch_config(path):
+    return read_config(path).fetch()
 
 
 def read_yaml(filename):
@@ -76,14 +76,12 @@ class OrderlyWebConfigBase:
         data = config_data_update(self.path, self.data, extra, options)
         return OrderlyWebConfig(self.path, data)
 
-    def fetch(self, error=False):
+    def fetch(self):
         try:
             with docker_client() as cl:
                 name = self.containers[PATH_CONFIG["container"]]
                 container = cl.containers.get(name)
         except docker.errors.NotFound:
-            if error:
-                raise
             return None
         path = PATH_CONFIG["path"]
         txt = string_from_container(container, path)
@@ -164,17 +162,6 @@ class OrderlyWebConfig:
         container = self.get_container(PATH_CONFIG["container"])
         path = PATH_CONFIG["path"]
         string_into_container(txt, container, path)
-
-    def fetch(self, error=True):
-        try:
-            container = self.get_container(PATH_CONFIG["container"])
-        except docker.errors.NotFound:
-            if error:
-                raise
-            return None
-        path = PATH_CONFIG["path"]
-        txt = string_from_container(container, path)
-        return pickle.loads(base64.b64decode(txt))
 
     def get_container(self, name):
         with docker_client() as cl:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -14,9 +14,13 @@ def read_config_data(path, extra=None, options=None):
     dat = read_yaml("{}/orderly-web.yml".format(path))
     if extra:
         dat_extra = read_yaml("{}/{}.yml".format(path, extra))
+        if "container_prefix" in dat_extra:
+            raise Exception("'container_prefix' may not be modified")
         dat = combine(dat, dat_extra)
     if options:
         dat = combine(dat, options)
+        if "container_prefix" in options:
+            raise Exception("'container_prefix' may not be modified")
     return dat
 
 

--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -66,8 +66,20 @@ def remove_volume(client, name):
 
 
 def container_exists(client, name):
+    return docker_exists(client.containers, name)
+
+
+def network_exists(client, name):
+    return docker_exists(client.networks, name)
+
+
+def volume_exists(client, name):
+    return docker_exists(client.volumes, name)
+
+
+def docker_exists(collection, name):
     try:
-        client.containers.get(name)
+        collection.get(name)
         return True
     except docker.errors.NotFound:
         return False

--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -124,6 +124,22 @@ def string_into_container(txt, container, path):
         container.put_archive(os.path.dirname(path), tar)
 
 
+def string_from_container(container, path):
+    stream, status = container.get_archive(path)
+    try:
+        fd, tmp = tempfile.mkstemp(text=False)
+        with os.fdopen(fd, "wb") as f:
+            for d in stream:
+                f.write(d)
+        with open(tmp, "rb") as f:
+            t = tarfile.open(mode="r", fileobj=f)
+            p = t.extractfile(os.path.basename(path))
+            txt = p.readlines()
+            return "\n".join([x.decode("utf8") for x in txt])
+    finally:
+        os.remove(tmp)
+
+
 # There is an annoyance with docker and the requests library, where
 # when the http handle is reclaimed a warning is printed.  It makes
 # the test log almost impossible to read.

--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -119,9 +119,9 @@ def simple_tar_string(text, name):
 #
 # So this function assumes that the destination directory exists and
 # dumps out text into a file in the container
-def string_into_container(container, txt, dest):
-    with simple_tar_string(txt, os.path.basename(dest)) as tar:
-        container.put_archive(os.path.dirname(dest), tar)
+def string_into_container(txt, container, path):
+    with simple_tar_string(txt, os.path.basename(path)) as tar:
+        container.put_archive(os.path.dirname(path), tar)
 
 
 # There is an annoyance with docker and the requests library, where

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -55,7 +55,7 @@ def orderly_write_env(env, container):
     print("Writing orderly environment")
     dest = "/orderly/orderly_envir.yml"
     txt = "".join(["{}: {}\n".format(str(k), str(v)) for k, v in env.items()])
-    string_into_container(container, txt, dest)
+    string_into_container(txt, container, dest)
 
 
 def orderly_init_demo(container):
@@ -116,7 +116,7 @@ def web_container_config(cfg, container):
             "orderly.server": "{}:8321".format(cfg.containers["orderly"])}
     txt = "".join(["{}={}\n".format(k, v) for k, v in opts.items()])
     exec_safely(container, ["mkdir", "-p", "/etc/orderly/web"])
-    string_into_container(container, txt, "/etc/orderly/web/config.properties")
+    string_into_container(txt, container, "/etc/orderly/web/config.properties")
 
 
 def web_migrate(cfg, docker_client):
@@ -161,7 +161,7 @@ def proxy_certificates(cfg, container):
         exec_safely(container, ["self-signed-certificate", "/run/proxy"])
     else:
         print("Copying ssl certificate and key into proxy")
-        string_into_container(container, cfg.proxy_ssl_certificate,
+        string_into_container(cfg.proxy_ssl_certificate, container,
                               "/run/proxy/certificate.pem")
-        string_into_container(container, cfg.proxy_ssl_key,
+        string_into_container(cfg.proxy_ssl_key, container,
                               "/run/proxy/key.pem")

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -1,6 +1,6 @@
 import docker
 
-from orderly_web.config import read_config
+from orderly_web.config import build_config
 from orderly_web.status import status
 from orderly_web.pull import pull
 from orderly_web.docker_helpers import docker_client, \
@@ -16,7 +16,7 @@ def start(path, extra=None, options=None, pull_images=False):
                 name, data["status"])
             print(msg)
             return False
-    cfg = read_config(path, extra, options)
+    cfg = build_config(path, extra, options)
     cfg.resolve_secrets()
     if pull_images:
         pull(cfg)

--- a/orderly_web/status.py
+++ b/orderly_web/status.py
@@ -4,6 +4,10 @@ from orderly_web.config import read_config
 from orderly_web.docker_helpers import docker_client
 
 
+def print_status(path):
+    print(status(path))
+
+
 def status(path):
     return OrderlyWebStatus(path)
 

--- a/orderly_web/stop.py
+++ b/orderly_web/stop.py
@@ -5,7 +5,7 @@ from orderly_web.docker_helpers import *
 
 
 def stop(path, kill=False, network=False, volumes=False):
-    cfg = fetch_config(path, False)
+    cfg = fetch_config(path)
 
     if cfg:
         print("Stopping OrderlyWeb from '{}'".format(path))

--- a/orderly_web/stop.py
+++ b/orderly_web/stop.py
@@ -1,12 +1,11 @@
 import docker
 
-from orderly_web.config import read_config
+from orderly_web.config import fetch_config
 from orderly_web.docker_helpers import *
 
 
 def stop(path, kill=False, network=False, volumes=False):
-    cfg_base = read_config(path)
-    cfg = cfg_base.fetch(False)
+    cfg = fetch_config(path, False)
 
     if cfg:
         print("Stopping OrderlyWeb from '{}'".format(path))

--- a/orderly_web/stop.py
+++ b/orderly_web/stop.py
@@ -1,16 +1,24 @@
 import docker
 
+from orderly_web.config import read_config
 from orderly_web.docker_helpers import *
 
 
-def stop(cfg, kill=False, network=False, volumes=False):
-    with docker_client() as client:
-        if "proxy" in cfg.containers:
-            stop_and_remove_container(client, cfg.containers["proxy"], kill)
-        stop_and_remove_container(client, cfg.containers["web"], kill)
-        stop_and_remove_container(client, cfg.containers["orderly"], kill)
-        if network:
-            remove_network(client, cfg.network)
-        if volumes:
-            for v in cfg.volumes.values():
-                remove_volume(client, v)
+def stop(path, kill=False, network=False, volumes=False):
+    cfg_base = read_config(path)
+    cfg = cfg_base.fetch(False)
+
+    if cfg:
+        print("Stopping OrderlyWeb from '{}'".format(path))
+        with docker_client() as client:
+            if "proxy" in cfg.containers:
+                stop_and_remove_container(client, cfg.containers["proxy"], kill)
+            stop_and_remove_container(client, cfg.containers["web"], kill)
+            stop_and_remove_container(client, cfg.containers["orderly"], kill)
+            if network:
+                remove_network(client, cfg.network)
+            if volumes:
+                for v in cfg.volumes.values():
+                    remove_volume(client, v)
+    else:
+        print("OrderlyWeb not running from '{}'".format(path))

--- a/orderly_web/stop.py
+++ b/orderly_web/stop.py
@@ -11,7 +11,8 @@ def stop(path, kill=False, network=False, volumes=False):
         print("Stopping OrderlyWeb from '{}'".format(path))
         with docker_client() as client:
             if "proxy" in cfg.containers:
-                stop_and_remove_container(client, cfg.containers["proxy"], kill)
+                stop_and_remove_container(client, cfg.containers["proxy"],
+                                          kill)
             stop_and_remove_container(client, cfg.containers["web"], kill)
             stop_and_remove_container(client, cfg.containers["orderly"], kill)
             if network:

--- a/test/test_cli_parse.py
+++ b/test/test_cli_parse.py
@@ -55,9 +55,15 @@ def test_string_to_dict():
     assert string_to_dict("a=x") == {"a": "x"}
     assert string_to_dict("a.b=x") == {"a": {"b": "x"}}
     assert string_to_dict("a.b.c=x") == {"a": {"b": {"c": "x"}}}
+    assert string_to_dict("a.b.c=True") == {"a": {"b": {"c": True}}}
+    assert string_to_dict("a.b.c=1") == {"a": {"b": {"c": 1}}}
+    assert string_to_dict("a.b.c=1.23") == {"a": {"b": {"c": 1.23}}}
     msg = "Invalid option 'foo', expected option in form key=value"
     with pytest.raises(Exception, match=msg):
         string_to_dict("foo")
     msg = "Invalid option 'a=b=c', expected option in form key=value"
     with pytest.raises(Exception, match=msg):
         string_to_dict("a=b=c")
+    msg = "Invalid value '{}' - expected simple type"
+    with pytest.raises(Exception, match=msg):
+        string_to_dict("a={}")

--- a/test/test_cli_parse.py
+++ b/test/test_cli_parse.py
@@ -3,6 +3,7 @@ import pytest
 import orderly_web
 import orderly_web.cli
 from orderly_web.cli import string_to_dict
+from orderly_web.status import print_status
 
 
 def test_cli_parse_start():
@@ -26,6 +27,21 @@ def test_cli_parse_start_with_options():
     assert args == ("path", None, options, False)
 
 
+def test_cli_parse_status():
+    target, args = orderly_web.cli.parse_args(["status", "path"])
+    assert target == print_status
+    assert args == ("path", )
+
+
+def test_cli_parse_stop():
+    target, args = orderly_web.cli.parse_args(["stop", "path"])
+    assert target == orderly_web.stop
+    assert args == ("path", False)
+    target, args = orderly_web.cli.parse_args(["stop", "path", "--kill"])
+    assert target == orderly_web.stop
+    assert args == ("path", True)
+
+
 def test_cli_parse_validate_options():
     msg = "Invalid option 'foo', expected option in form key=value"
     with pytest.raises(Exception, match=msg):
@@ -36,6 +52,12 @@ def test_cli_parse_validate_options():
 
 
 def test_string_to_dict():
-    assert string_to_dict("a", "x") == {"a": "x"}
-    assert string_to_dict("a.b", "x") == {"a": {"b": "x"}}
-    assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}
+    assert string_to_dict("a=x") == {"a": "x"}
+    assert string_to_dict("a.b=x") == {"a": {"b": "x"}}
+    assert string_to_dict("a.b.c=x") == {"a": {"b": {"c": "x"}}}
+    msg = "Invalid option 'foo', expected option in form key=value"
+    with pytest.raises(Exception, match=msg):
+        string_to_dict("foo")
+    msg = "Invalid option 'a=b=c', expected option in form key=value"
+    with pytest.raises(Exception, match=msg):
+        string_to_dict("a=b=c")

--- a/test/test_cli_parse.py
+++ b/test/test_cli_parse.py
@@ -1,0 +1,41 @@
+import pytest
+
+import orderly_web
+import orderly_web.cli
+from orderly_web.cli import string_to_dict
+
+
+def test_cli_parse_start():
+    target, args = orderly_web.cli.parse_args(["start", "path"])
+    assert target == orderly_web.start
+    assert args == ("path", None, [], False)
+
+
+def test_cli_parse_start_with_extra():
+    target, args = orderly_web.cli.parse_args(
+        ["start", "path", "--extra=extra.yml"])
+    assert target == orderly_web.start
+    assert args == ("path", "extra.yml", [], False)
+
+
+def test_cli_parse_start_with_options():
+    target, args = orderly_web.cli.parse_args(
+        ["start", "path", "--option=a=x", "--option=b.c=y"])
+    assert target == orderly_web.start
+    options = [{'a': 'x'}, {'b': {'c': 'y'}}]
+    assert args == ("path", None, options, False)
+
+
+def test_cli_parse_validate_options():
+    msg = "Invalid option 'foo', expected option in form key=value"
+    with pytest.raises(Exception, match=msg):
+        orderly_web.cli.parse_args(["start", "path", "--option=foo"])
+    msg = "Invalid option 'a=b=c', expected option in form key=value"
+    with pytest.raises(Exception, match=msg):
+        orderly_web.cli.parse_args(["start", "path", "--option=a=b=c"])
+
+
+def test_string_to_dict():
+    assert string_to_dict("a", "x") == {"a": "x"}
+    assert string_to_dict("a.b", "x") == {"a": {"b": "x"}}
+    assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -138,7 +138,7 @@ def test_string_to_dict():
     assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}
 
 
-def test_read_and_patch():
+def test_read_and_extra():
     with tempfile.TemporaryDirectory() as p:
         shutil.copy("config/basic/orderly-web.yml", p)
         with open("{}/patch.yml".format(p), "w+") as f:
@@ -146,6 +146,28 @@ def test_read_and_patch():
             yaml.dump(data, f)
         cfg = read_config(p, "patch")
         assert cfg.container_prefix == "patched_orderly_web"
+
+
+def test_read_and_options():
+    options = {"container_prefix": "patched_orderly_web"}
+    cfg = read_config("config/basic", options=options)
+    assert cfg.container_prefix == "patched_orderly_web"
+
+
+def test_read_complex():
+    with tempfile.TemporaryDirectory() as p:
+        shutil.copy("config/basic/orderly-web.yml", p)
+        data1 = {"container_prefix": "prefix1",
+                 "volumes": {"proxy_logs": "mylogs"}}
+        data2 = {"container_prefix": "prefix2",
+                 "volumes": {"orderly": "mydata"}}
+        with open("{}/patch.yml".format(p), "w+") as f:
+            data = {"container_prefix": "patched_orderly_web"}
+            yaml.dump(data1, f)
+        cfg = read_config(p, "patch", data2)
+        assert cfg.container_prefix == "prefix2"
+        assert cfg.volumes["orderly"] == "mydata"
+        assert cfg.volumes["proxy_logs"] == "mylogs"
 
 
 def read_file(path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -142,32 +142,50 @@ def test_read_and_extra():
     with tempfile.TemporaryDirectory() as p:
         shutil.copy("config/basic/orderly-web.yml", p)
         with open("{}/patch.yml".format(p), "w+") as f:
-            data = {"container_prefix": "patched_orderly_web"}
+            data = {"network": "patched_network"}
             yaml.dump(data, f)
         cfg = read_config(p, "patch")
-        assert cfg.container_prefix == "patched_orderly_web"
+        assert cfg.network == "patched_network"
 
 
 def test_read_and_options():
-    options = {"container_prefix": "patched_orderly_web"}
+    options = {"network": "patched_network"}
     cfg = read_config("config/basic", options=options)
-    assert cfg.container_prefix == "patched_orderly_web"
+    assert cfg.network == "patched_network"
 
 
 def test_read_complex():
     with tempfile.TemporaryDirectory() as p:
         shutil.copy("config/basic/orderly-web.yml", p)
-        data1 = {"container_prefix": "prefix1",
+        data1 = {"network": "network1",
                  "volumes": {"proxy_logs": "mylogs"}}
-        data2 = {"container_prefix": "prefix2",
+        data2 = {"network": "network2",
                  "volumes": {"orderly": "mydata"}}
         with open("{}/patch.yml".format(p), "w+") as f:
-            data = {"container_prefix": "patched_orderly_web"}
+            data = {"network": "patched_network"}
             yaml.dump(data1, f)
         cfg = read_config(p, "patch", data2)
-        assert cfg.container_prefix == "prefix2"
+        assert cfg.network == "network2"
         assert cfg.volumes["orderly"] == "mydata"
         assert cfg.volumes["proxy_logs"] == "mylogs"
+
+
+def test_cant_overwrite_prefix_with_patch():
+    with tempfile.TemporaryDirectory() as p:
+        shutil.copy("config/basic/orderly-web.yml", p)
+        with open("{}/patch.yml".format(p), "w+") as f:
+            data = {"container_prefix": "patched_orderly_web"}
+            yaml.dump(data, f)
+        with pytest.raises(Exception,
+                           match="'container_prefix' may not be modified"):
+            read_config(p, "patch")
+
+
+def test_cant_overwrite_prefix_with_options():
+    with pytest.raises(Exception,
+                       match="'container_prefix' may not be modified"):
+        options = {"container_prefix": "patched_orderly_web"}
+        read_config("config/basic", options=options)
 
 
 def read_file(path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -3,7 +3,7 @@ import vault_dev
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
     config_image_reference, read_config, DockerImageReference, \
-    combine, combine2
+    combine, combine2, string_to_dict
 
 sample_data = {"a": "value1", "b": {"x": "value2"}, "c": 1, "d": True,
                "e": None}
@@ -133,6 +133,11 @@ def test_combine():
     assert combine({"a": 1, "b": 1, "c": 1}, {"a": 2, "b": 2}, {"a": 3}) == \
         {"a": 3, "b": 2, "c": 1}
 
+
+def test_string_to_dict():
+    assert string_to_dict("a", "x") == {"a": "x"}
+    assert string_to_dict("a.b", "x") == {"a": {"b": "x"}}
+    assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}
 
 
 def read_file(path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,7 +6,7 @@ import yaml
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
     config_image_reference, build_config, DockerImageReference, \
-    combine, string_to_dict
+    combine
 
 sample_data = {"a": "value1", "b": {"x": "value2"}, "c": 1, "d": True,
                "e": None}
@@ -130,12 +130,6 @@ def test_combine():
         {"a": {"x": 3, "y": 4}, "b": 2}
     assert combine({"a": None, "b": 2}, {"a": {"x": 3}}) == \
         {"a": {"x": 3}, "b": 2}
-
-
-def test_string_to_dict():
-    assert string_to_dict("a", "x") == {"a": "x"}
-    assert string_to_dict("a.b", "x") == {"a": {"b": "x"}}
-    assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}
 
 
 def test_read_and_extra():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -2,7 +2,8 @@ import pytest
 import vault_dev
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
-    config_image_reference, read_config, DockerImageReference
+    config_image_reference, read_config, DockerImageReference, \
+    combine, combine2
 
 sample_data = {"a": "value1", "b": {"x": "value2"}, "c": 1, "d": True,
                "e": None}
@@ -115,6 +116,23 @@ def test_can_substitute_secrets():
         assert cfg.proxy_ssl_certificate == cert
         assert cfg.proxy_ssl_key == key
         assert cfg.orderly_env["ORDERLY_DB_PASS"] == "s3cret"
+
+
+def test_combine2():
+    assert combine2({"a": 1}, {"b": 2}) == \
+        {"a": 1, "b": 2}
+    assert combine2({"a": {"x": 1}, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3}, "b": 2}
+    assert combine2({"a": {"x": 1, "y": 4}, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3, "y": 4}, "b": 2}
+    assert combine2({"a": None, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3}, "b": 2}
+
+
+def test_combine():
+    assert combine({"a": 1, "b": 1, "c": 1}, {"a": 2, "b": 2}, {"a": 3}) == \
+        {"a": 3, "b": 2, "c": 1}
+
 
 
 def read_file(path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,8 @@
 import pytest
+import shutil
+import tempfile
 import vault_dev
+import yaml
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
     config_image_reference, read_config, DockerImageReference, \
@@ -138,6 +141,16 @@ def test_string_to_dict():
     assert string_to_dict("a", "x") == {"a": "x"}
     assert string_to_dict("a.b", "x") == {"a": {"b": "x"}}
     assert string_to_dict("a.b.c", "x") == {"a": {"b": {"c": "x"}}}
+
+
+def test_read_and_patch():
+    with tempfile.TemporaryDirectory() as p:
+        shutil.copy("config/basic/orderly-web.yml", p)
+        with open("{}/patch.yml".format(p), "w+") as f:
+            data = {"container_prefix": "patched_orderly_web"}
+            yaml.dump(data, f)
+        cfg = read_config(p, "patch")
+        assert cfg.container_prefix == "patched_orderly_web"
 
 
 def read_file(path):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,7 +6,7 @@ import yaml
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
     config_image_reference, read_config, DockerImageReference, \
-    combine, combine2, string_to_dict
+    combine, string_to_dict
 
 sample_data = {"a": "value1", "b": {"x": "value2"}, "c": 1, "d": True,
                "e": None}
@@ -121,20 +121,15 @@ def test_can_substitute_secrets():
         assert cfg.orderly_env["ORDERLY_DB_PASS"] == "s3cret"
 
 
-def test_combine2():
-    assert combine2({"a": 1}, {"b": 2}) == \
-        {"a": 1, "b": 2}
-    assert combine2({"a": {"x": 1}, "b": 2}, {"a": {"x": 3}}) == \
-        {"a": {"x": 3}, "b": 2}
-    assert combine2({"a": {"x": 1, "y": 4}, "b": 2}, {"a": {"x": 3}}) == \
-        {"a": {"x": 3, "y": 4}, "b": 2}
-    assert combine2({"a": None, "b": 2}, {"a": {"x": 3}}) == \
-        {"a": {"x": 3}, "b": 2}
-
-
 def test_combine():
-    assert combine({"a": 1, "b": 1, "c": 1}, {"a": 2, "b": 2}, {"a": 3}) == \
-        {"a": 3, "b": 2, "c": 1}
+    assert combine({"a": 1}, {"b": 2}) == \
+        {"a": 1, "b": 2}
+    assert combine({"a": {"x": 1}, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3}, "b": 2}
+    assert combine({"a": {"x": 1, "y": 4}, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3, "y": 4}, "b": 2}
+    assert combine({"a": None, "b": 2}, {"a": {"x": 3}}) == \
+        {"a": {"x": 3}, "b": 2}
 
 
 def test_string_to_dict():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -5,7 +5,7 @@ import vault_dev
 import yaml
 
 from orderly_web.config import config_string, config_integer, config_boolean, \
-    config_image_reference, read_config, DockerImageReference, \
+    config_image_reference, build_config, DockerImageReference, \
     combine, string_to_dict
 
 sample_data = {"a": "value1", "b": {"x": "value2"}, "c": 1, "d": True,
@@ -52,7 +52,7 @@ def test_config_boolean():
 
 
 def test_example_config():
-    cfg = read_config("config/basic")
+    cfg = build_config("config/basic")
     assert cfg.network == "orderly_web_network"
     assert cfg.volumes["orderly"] == "orderly_web_volume"
     assert cfg.containers["orderly"] == "orderly_web_orderly"
@@ -93,7 +93,7 @@ def test_config_image_reference():
 
 
 def test_config_no_proxy():
-    cfg = read_config("config/noproxy")
+    cfg = build_config("config/noproxy")
     assert not cfg.proxy_enabled
 
 
@@ -110,7 +110,7 @@ def test_can_substitute_secrets():
 
         # When reading the configuration we have to interpolate in the
         # correct values here for the vault connection
-        cfg = read_config("config/complete")
+        cfg = build_config("config/complete")
         cfg.vault.url = "http://localhost:{}".format(s.port)
         cfg.vault.auth_args["token"] = s.token
 
@@ -144,13 +144,13 @@ def test_read_and_extra():
         with open("{}/patch.yml".format(p), "w+") as f:
             data = {"network": "patched_network"}
             yaml.dump(data, f)
-        cfg = read_config(p, "patch")
+        cfg = build_config(p, "patch")
         assert cfg.network == "patched_network"
 
 
 def test_read_and_options():
     options = {"network": "patched_network"}
-    cfg = read_config("config/basic", options=options)
+    cfg = build_config("config/basic", options=options)
     assert cfg.network == "patched_network"
 
 
@@ -164,7 +164,7 @@ def test_read_complex():
         with open("{}/patch.yml".format(p), "w+") as f:
             data = {"network": "patched_network"}
             yaml.dump(data1, f)
-        cfg = read_config(p, "patch", data2)
+        cfg = build_config(p, "patch", data2)
         assert cfg.network == "network2"
         assert cfg.volumes["orderly"] == "mydata"
         assert cfg.volumes["proxy_logs"] == "mylogs"
@@ -178,14 +178,14 @@ def test_cant_overwrite_prefix_with_patch():
             yaml.dump(data, f)
         with pytest.raises(Exception,
                            match="'container_prefix' may not be modified"):
-            read_config(p, "patch")
+            build_config(p, "patch")
 
 
 def test_cant_overwrite_prefix_with_options():
     with pytest.raises(Exception,
                        match="'container_prefix' may not be modified"):
         options = {"container_prefix": "patched_orderly_web"}
-        read_config("config/basic", options=options)
+        build_config("config/basic", options=options)
 
 
 def read_file(path):

--- a/test/test_docker_helpers.py
+++ b/test/test_docker_helpers.py
@@ -63,16 +63,16 @@ def test_container_wait_running_returns_cintainer():
 def test_that_removing_missing_container_is_harmless():
     with docker_client() as cl:
         nm = "orderly_web_noncontainer"
-        stop_and_remove_container(client, name, True)
+        stop_and_remove_container(cl, nm, True)
 
 
 def test_that_removing_missing_network_is_harmless():
     with docker_client() as cl:
         nm = "orderly_web_nonnetwork"
-        remove_network(client, name)
+        remove_network(cl, nm)
 
 
 def test_that_removing_missing_volume_is_harmless():
     with docker_client() as cl:
         nm = "orderly_web_nonvolume"
-        remove_volume(client, name)
+        remove_volume(cl, nm)

--- a/test/test_docker_helpers.py
+++ b/test/test_docker_helpers.py
@@ -58,3 +58,21 @@ def test_container_wait_running_returns_cintainer():
         assert res == container
         container.kill()
         container.remove()
+
+
+def test_that_removing_missing_container_is_harmless():
+    with docker_client() as cl:
+        nm = "orderly_web_noncontainer"
+        stop_and_remove_container(client, name, True)
+
+
+def test_that_removing_missing_network_is_harmless():
+    with docker_client() as cl:
+        nm = "orderly_web_nonnetwork"
+        remove_network(client, name)
+
+
+def test_that_removing_missing_volume_is_harmless():
+    with docker_client() as cl:
+        nm = "orderly_web_nonvolume"
+        remove_volume(client, name)

--- a/test/test_docker_helpers.py
+++ b/test/test_docker_helpers.py
@@ -27,7 +27,7 @@ def test_string_into_container():
         container = cl.containers.run("alpine", ["sleep", "20"],
                                       detach=True, auto_remove=True)
         text = "a\nb\nc\n"
-        string_into_container(container, text, "/test")
+        string_into_container(text, container, "/test")
         out = container.exec_run(["cat", "/test"])
         assert out[0] == 0
         assert out[1].decode("UTF-8") == text

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -39,8 +39,8 @@ def test_start_and_stop():
         st = orderly_web.status(path)
         assert st.containers["orderly"]["status"] == "running"
         assert st.containers["web"]["status"] == "running"
-        assert st.volumes["orderly"]["status"] == "created"
-        assert st.network["status"] == "up"
+        assert st.volumes["orderly"] == "orderly_web_volume"
+        assert st.network == "orderly_web_network"
 
         f = io.StringIO()
         with redirect_stdout(f):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -10,6 +10,7 @@ from orderly_web.config import fetch_config
 from orderly_web.docker_helpers import *
 import orderly_web
 
+
 def test_status_when_not_running():
     st = orderly_web.status("config/basic")
     assert not st.is_running


### PR DESCRIPTION
This PR will expand the way that the deploy is configured to allow a base configuration that is modifiable.

This is the pattern that we will have with montagu: there will be a "base" configuration and then tweaks to that configuration to turn it into production/science/uat, or to tune an image version for example.

The interface at the end of all of this is to be able to write:

```
orderly-web start montagu --extra=production.yml
```

which will take the configuration at `montagu/orderly_web.yml` and patch it with yaml in `montagu/production.yml`.  

For testing or more minor tweaks one can do

```
orderly-web start montagu --option=web.dev_mode=True
```

this approach is used within this PR for providing the vault address.

There is a bunch of verbiage justifying the approach towards the top of config.py
