### PR TITLE
mrc-276: Set the app url in the configuration

### DIFF
--- a/config/basic/orderly-web.yml
+++ b/config/basic/orderly-web.yml
@@ -47,6 +47,12 @@ web:
     name: orderly-web
     tag: master
     migrate: orderlyweb-migrate
+  ## Public-facing url for the whole web service, including protocol
+  ## (ideally https://), hostname and port (if not using standard
+  ## ports).  Here, we're going to use the same as for the proxy but
+  ## if you are using an external proxy then you'd use its hostname
+  ## and port.
+  url: https://localhost
   ## If dev_mode is true then the port is exposed to the host (as
   ## plain http).  Do not use in production.  The port is attached
   ## only to the localhost and will not be available from other

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -99,7 +99,7 @@ web:
   image:
     repo: vimc
     name: orderly-web
-    tag: master
+    tag: mrc-286
     migrate: orderlyweb-migrate
     css-generator: orderly-web-css-generator
   ## Public-facing url for the whole web service, including protocol

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -99,9 +99,15 @@ web:
   image:
     repo: vimc
     name: orderly-web
-    tag: mrc-286
+    tag: master
     migrate: orderlyweb-migrate
     css-generator: orderly-web-css-generator
+  ## Public-facing url for the whole web service, including protocol
+  ## (ideally https://), hostname and port (if not using standard
+  ## ports).  Here, we're going to use the same as for the proxy but
+  ## if you are using an external proxy then you'd use its hostname
+  ## and port.
+  url: https://localhost
   ## If dev_mode is true then the port is exposed to the host (as
   ## plain http).  Do not use in production.  The port is attached
   ## only to the localhost and will not be available from other

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -184,7 +184,7 @@ class OrderlyWebConfig:
             if self.proxy_enabled:
                 self.web_url = "https://{}:{}".format(
                     self.proxy_hostname, self.proxy_port_https)
-            elif self.web.dev_mode:
+            elif self.web_dev_mode:
                 self.web_url = "http://localhost:{}".format(self.web_port)
             else:
                 raise Error("web_url must be provided")

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -179,6 +179,16 @@ class OrderlyWebConfig:
         else:
             self.proxy_enabled = False
 
+        self.web_url = config_string(dat, ["web", "url"], True)
+        if not self.web_url:
+            if self.proxy_enabled:
+                self.web_url = "https://{}:{}".format(
+                    self.proxy_hostname, self.proxy_port_https)
+            elif self.web.dev_mode:
+                self.web_url = "http://localhost:{}".format(self.web_port)
+            else:
+                raise Error("web_url must be provided")
+
     def save(self):
         orderly = self.get_container("orderly")
         txt = base64.b64encode(pickle.dumps(self)).decode("utf8")

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -187,7 +187,7 @@ class OrderlyWebConfig:
             elif self.web_dev_mode:
                 self.web_url = "http://localhost:{}".format(self.web_port)
             else:
-                raise Error("web_url must be provided")
+                raise Exception("web_url must be provided")
 
     def save(self):
         orderly = self.get_container("orderly")

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -122,6 +122,7 @@ def web_container_config(cfg, container):
     opts = {"app.port": str(cfg.web_port),
             "app.name": cfg.web_name,
             "app.email": cfg.web_email,
+            "app.url": cfg.web_url,
             "auth.github_org": cfg.web_auth_github_org,
             "auth.github_team": cfg.web_auth_github_team,
             "auth.fine_grained": str(cfg.web_auth_fine_grained).lower(),

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -219,6 +219,26 @@ def test_update_config_with_options_dict():
     assert data.network == "patched_network"
 
 
+def test_web_url_is_read_from_config():
+    data = build_config("config/basic")
+    assert data.web_url == "https://localhost"
+
+
+def test_web_url_default_depends_on_proxy():
+    options = {"web": {"url": None}}
+    data = build_config("config/basic", options=options)
+    assert data.web_url == "https://localhost:443"
+    data = build_config("config/noproxy", options=options)
+    assert data.web_url == "http://localhost:8888"
+
+
+def test_web_url_required_if_not_proxied():
+    with pytest.raises(Exception,
+                       match="web_url must be provided"):
+        options = {"web": {"url": None, "dev_mode": False}}
+        build_config("config/noproxy", options=options)
+
+
 def read_file(path):
     with open(path, "r") as f:
         return f.read()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -104,7 +104,7 @@ def test_start_with_custom_styles():
         cfg = fetch_config(path)
 
         # check that the style volume is really mounted
-        api_client = docker.client.from_env().api()
+        api_client = docker.client.from_env().api
         details = api_client.inspect_container(cfg.containers["web"])
         assert len(details['Mounts']) == 3
         css_volume = [v for v in details['Mounts']

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -92,7 +92,8 @@ def test_start_and_stop():
 def test_start_with_custom_styles():
     path = "config/customcss"
     try:
-        res = orderly_web.start(path)
+        options = {"web": {"url": "http://localhost:8888"}}
+        res = orderly_web.start(path, options=options)
         assert res
         st = orderly_web.status(path)
         assert st.containers["orderly"]["status"] == "running"
@@ -103,7 +104,7 @@ def test_start_with_custom_styles():
         cfg = fetch_config(path)
 
         # check that the style volume is really mounted
-        api_client = docker.APIClient(base_url='unix://var/run/docker.sock')
+        api_client = docker.client.from_env().api()
         details = api_client.inspect_container(cfg.containers["web"])
         assert len(details['Mounts']) == 3
         css_volume = [v for v in details['Mounts']

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -157,7 +157,8 @@ def test_admin_cli():
 
 def test_no_devmode_no_ports():
     path = "config/noproxy"
-    options = {"web": {"dev_mode": False}}
+    options = {"web": {"dev_mode": False,
+                       "url": "http://localhost"}}
 
     try:
         orderly_web.start(path, options=options)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -59,6 +59,10 @@ def test_start_and_stop():
         dat = json.loads(http_get("http://localhost:8888/api/v1"))
         assert dat["status"] == "success"
 
+        web_config = string_from_container(
+            web, "/etc/orderly/web/config.properties")
+        assert "app.url=https://localhost" in web_config.split("\n")
+
         # Trivial check that the proxy container works too:
         proxy = cfg.get_container("proxy")
         ports = proxy.attrs["HostConfig"]["PortBindings"]


### PR DESCRIPTION
This PR allows the app url (as specified in `/etc/orderly/web/config.properties`) to be configured using the `orderly_web.yml`.

Some (hopefully) sensible defaults here when not provided, but practically this is something that people probably should include.
