### PR TITLE
mrc-333: Require github if not using montagu

### DIFF
--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -131,16 +131,18 @@ class OrderlyWebConfig:
             dat, ["web", "auth", "montagu"])
         self.web_auth_fine_grained = config_boolean(
             dat, ["web", "auth", "fine_grained"])
-        self.web_auth_github_org = config_string(
-            dat, ["web", "auth", "github_org"], True)
-        self.web_auth_github_team = config_string(
-            dat, ["web", "auth", "github_team"], True)
 
         if not self.web_auth_montagu:
             self.web_auth_github_app = config_dict(dat, ["web", "auth",
                                                          "github_oauth"])
+            self.web_auth_github_org = config_string(
+                dat, ["web", "auth", "github_org"])
+            self.web_auth_github_team = config_string(
+                dat, ["web", "auth", "github_team"], True)
         else:
             self.web_auth_github_app = None
+            self.web_auth_github_org = None
+            self.web_auth_github_team = None
 
         if self.web_auth_montagu:
             self.montagu_url = config_string(dat,

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -143,8 +143,8 @@ def web_container_config(cfg, container):
             "app.name": cfg.web_name,
             "app.email": cfg.web_email,
             "app.url": cfg.web_url,
-            "auth.github_org": cfg.web_auth_github_org,
-            "auth.github_team": cfg.web_auth_github_team,
+            "auth.github_org": cfg.web_auth_github_org or "",
+            "auth.github_team": cfg.web_auth_github_team or "",
             "auth.fine_grained": str(cfg.web_auth_fine_grained).lower(),
             "auth.provider": "montagu" if cfg.web_auth_montagu else "github",
             "orderly.server": "http://{}:8321".format(orderly_container)}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -270,6 +270,22 @@ def test_web_url_required_if_not_proxied():
         build_config("config/noproxy", options=options)
 
 
+def test_github_auth_required_if_not_using_montagu():
+    with pytest.raises(KeyError, match="web:auth:github_org"):
+        options = {"web": {"auth": {"github_org": None}}}
+        cfg = build_config("config/basic", options=options)
+
+
+def test_github_auth_ignored_if_using_montagu():
+    options = {"web": {"auth": {"montagu": True,
+                                "montagu_url": "https://localhost",
+                                "montagu_api_url": "https://localhost"}}}
+    cfg = build_config("config/basic", options=options)
+    assert cfg.web_auth_github_app is None
+    assert cfg.web_auth_github_org is None
+    assert cfg.web_auth_github_team is None
+
+
 def read_file(path):
     with open(path, "r") as f:
         return f.read()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -251,6 +251,8 @@ def test_start_with_montagu_config():
 
         assert "montagu.url=http://montagu" in web_config
         assert "montagu.api_url=http://montagu/api" in web_config
+        assert 'auth.github_org=' in web_config
+        assert 'auth.github_team=' in web_config
 
     finally:
         orderly_web.stop(path, kill=True, volumes=True, network=True)


### PR DESCRIPTION
This PR cleans up the logic with github and montagu auth, making them mutually exclusive options