### PR TITLE
mrc-334: Configure ssh keys into the orderly container

### DIFF
--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -79,6 +79,13 @@ orderly:
     ORDERLY_DB_HOST: db_host
     ORDERLY_DB_USER: db_user
     ORDERLY_DB_PASS: VAULT:secret/db/password:value
+  ## Path to ssh key for interacting with git; this will be set up at
+  ## ~/.ssh in the orderly container so that pull and fetch work.  You
+  ## might use a github deploy key here.  For completeness both the
+  ## public and private parts of the keypair are listed.
+  ssh:
+    public: VAULT:secret/ssh:public
+    private: VAULT:secret/ssh:private
 
 
 ## Api and Website configuration

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -328,7 +328,7 @@ def config_dict_strict(data, path, keys, is_optional=False):
     for k, v in d.items():
         if type(v) is not str:
             raise ValueError("Expected a string for {}".format(
-            ":".join(path + [k])))
+                ":".join(path + [k])))
     return d
 
 

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -212,6 +212,13 @@ class OrderlyWebConfig:
             else:
                 raise Exception("web_url must be provided")
 
+        if "ssh" in dat["orderly"] and dat["orderly"]["ssh"]:
+            public = config_string(dat, ["orderly", "ssh", "public"])
+            private = config_string(dat, ["orderly", "ssh", "private"])
+            self.orderly_ssh = {"public": public, "private": private}
+        else:
+            self.orderly_ssh = None
+
     def save(self):
         orderly = self.get_container("orderly")
         txt = base64.b64encode(pickle.dumps(self)).decode("utf8")
@@ -228,6 +235,7 @@ class OrderlyWebConfig:
         vault.resolve_secrets(self, vault_client)
         vault.resolve_secrets(self.orderly_env, vault_client)
         vault.resolve_secrets(self.web_auth_github_app, vault_client)
+        vault.resolve_secrets(self.orderly_ssh, vault_client)
 
     def get_abs_path(self, relative_path):
         return os.path.abspath(os.path.join(self.path, relative_path))

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -97,6 +97,7 @@ def orderly_write_ssh_keys(orderly_ssh, container):
     string_into_container(hosts[1].decode("UTF-8"), container,
                           path_known_hosts)
 
+
 def orderly_start(container):
     print("Starting orderly server")
     exec_safely(container, ["touch", "/go_signal"])

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -50,6 +50,25 @@ def test_config_boolean():
     assert config_boolean(sample_data, "d")
 
 
+def test_config_dict_returns_dict():
+    assert config_dict(sample_data, ["b"]) == sample_data["b"]
+
+
+def test_config_dict_strict_returns_dict():
+    assert config_dict_strict(sample_data, ["b"], ["x"]) == sample_data["b"]
+
+
+def test_config_dict_strict_raises_if_keys_missing():
+    with pytest.raises(ValueError, match="Expected keys x, y for b"):
+        config_dict_strict(sample_data, ["b"], ["x", "y"])
+
+
+def test_config_dict_strict_raises_if_not_strings():
+    dat = {"a": {"b": {"c": 1}}}
+    with pytest.raises(ValueError, match="Expected a string for a:b:c"):
+        config_dict_strict(dat, ["a", "b"], "c")
+
+
 def test_example_config():
     cfg = build_config("config/basic")
     assert cfg.network == "orderly_web_network"

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -146,6 +146,8 @@ def test_can_substitute_secrets():
         cl.write("secret/db/password", value="s3cret")
         cl.write("secret/github/id", value="ghkey")
         cl.write("secret/github/secret", value="ghs3cret")
+        cl.write("secret/ssh", public="public-key-data",
+                 private="private-key-data")
 
         # When reading the configuration we have to interpolate in the
         # correct values here for the vault connection
@@ -160,6 +162,8 @@ def test_can_substitute_secrets():
         assert cfg.orderly_env["ORDERLY_DB_PASS"] == "s3cret"
         assert cfg.web_auth_github_app["id"] == "ghkey"
         assert cfg.web_auth_github_app["secret"] == "ghs3cret"
+        assert cfg.orderly_ssh["private"] == "private-key-data"
+        assert cfg.orderly_ssh["public"] == "public-key-data"
 
 
 def test_combine():

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -346,7 +346,8 @@ def test_vault_ssl():
         public = string_from_container(container, "/root/.ssh/id_rsa.pub")
         assert public == "public-key-data"
 
-        known_hosts = string_from_container(container, "/root/.ssh/known-hosts")
+        known_hosts = string_from_container(container,
+                                            "/root/.ssh/known_hosts")
         assert "github.com" in known_hosts
 
         web_container = cfg.get_container("web")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -323,6 +323,8 @@ def test_vault_ssl():
         cl.write("secret/db/password", value="s3cret")
         cl.write("secret/github/id", value="ghid")
         cl.write("secret/github/secret", value="ghs3cret")
+        cl.write("secret/ssh", public="public-key-data",
+                 private="private-key-data")
 
         path = "config/complete"
 
@@ -338,6 +340,14 @@ def test_vault_ssl():
         container = cfg.get_container("orderly")
         res = string_from_container(container, "/orderly/orderly_envir.yml")
         assert "ORDERLY_DB_PASS: s3cret" in res
+
+        private = string_from_container(container, "/root/.ssh/id_rsa")
+        assert private == "private-key-data"
+        public = string_from_container(container, "/root/.ssh/id_rsa.pub")
+        assert public == "public-key-data"
+
+        known_hosts = string_from_container(container, "/root/.ssh/known-hosts")
+        assert "github.com" in known_hosts
 
         web_container = cfg.get_container("web")
         web_config = string_from_container(


### PR DESCRIPTION
For working with the git repo in orderly, we (in vimc and in ebola) require ssh keys to be present.  We use either a robot key or a deploy key for this.

This PR adds new configuration that allows for keys to be copied into the container, and also runs "ssh-keyscan" which allows for unattended use of git-over-ssh (without this you have to manually accept the host certificate)

This is similar behaviour to our current montagu deployment