### PR TITLE
mrc-335: initialise orderly by clone or by demo

### DIFF
--- a/config/basic/orderly-web.yml
+++ b/config/basic/orderly-web.yml
@@ -27,6 +27,8 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  initial:
+    source: demo
 
 ## Api and Website configuration
 web:

--- a/config/basic/orderly-web.yml
+++ b/config/basic/orderly-web.yml
@@ -28,7 +28,12 @@ orderly:
     name: orderly.server
     tag: master
   initial:
-    source: demo
+    ## Source must be one of "clone" or "demo"
+    source: clone
+    ## If source is "clone", then "url" must be given.  If using a
+    ## private repo, then use an ssh url and provide ssh keys in the
+    ## "ssh" section.
+    url: https://github.com/reside-ic/orderly-example
 
 ## Api and Website configuration
 web:

--- a/config/basic/orderly-web.yml
+++ b/config/basic/orderly-web.yml
@@ -27,6 +27,11 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  ## Initial data source for the orderly reports.  This section is
+  ## optional - if not present, it is up to you to initialise the
+  ## orderly volume (in the volumes section above) with appropriate
+  ## data (if data is not present, orderly will not start).  This
+  ## section only has an effect if the volume is empty.
   initial:
     ## Source must be one of "clone" or "demo"
     source: clone

--- a/config/breaking/orderly-web.yml
+++ b/config/breaking/orderly-web.yml
@@ -11,6 +11,8 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  initial:
+    source: demo
 
 web:
   image:

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -86,7 +86,14 @@ orderly:
   ssh:
     public: VAULT:secret/ssh:public
     private: VAULT:secret/ssh:private
-
+  ## Initial data source
+  initial:
+    ## Source must be one of "clone" or "demo"
+    source: clone
+    ## If source is "clone", then "url" must be given.  If using a
+    ## private repo, then use an ssh url and provide ssh keys in the
+    ## "ssh" section.
+    url: https://github.com/reside-ic/orderly-example
 
 ## Api and Website configuration
 web:

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -86,7 +86,11 @@ orderly:
   ssh:
     public: VAULT:secret/ssh:public
     private: VAULT:secret/ssh:private
-  ## Initial data source
+  ## Initial data source for the orderly reports.  This section is
+  ## optional - if not present, it is up to you to initialise the
+  ## orderly volume (in the volumes section above) with appropriate
+  ## data (if data is not present, orderly will not start).  This
+  ## section only has an effect if the volume is empty.
   initial:
     ## Source must be one of "clone" or "demo"
     source: clone

--- a/config/customcss/orderly-web.yml
+++ b/config/customcss/orderly-web.yml
@@ -30,6 +30,8 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  initial:
+    source: demo
 
 ## Api and Website configuration
 web:

--- a/config/montagu/orderly-web.yml
+++ b/config/montagu/orderly-web.yml
@@ -27,6 +27,8 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  initial:
+    source: demo
 
 ## Api and Website configuration
 web:

--- a/config/noproxy/orderly-web.yml
+++ b/config/noproxy/orderly-web.yml
@@ -27,6 +27,8 @@ orderly:
     repo: vimc
     name: orderly.server
     tag: master
+  initial:
+    source: demo
 
 ## Api and Website configuration
 web:

--- a/config/vault/orderly-web.yml
+++ b/config/vault/orderly-web.yml
@@ -50,6 +50,8 @@ orderly:
     ORDERLY_DB_HOST: db_host
     ORDERLY_DB_USER: db_user
     ORDERLY_DB_PASS: VAULT:secret/db/password:value
+  initial:
+    source: demo
 
 ## Api and Website configuration
 web:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -365,7 +365,7 @@ def combine(base, extra):
     """Combine exactly two dictionaries recursively, modifying the first
 argument in place with the contets of the second"""
     for k, v in extra.items():
-        if k in base and type(base[k]) is dict:
+        if k in base and type(base[k]) is dict and v is not None:
             combine(base[k], v)
         else:
             base[k] = v

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -215,6 +215,18 @@ class OrderlyWebConfig:
         self.orderly_ssh = config_dict_strict(
             dat, ["orderly", "ssh"], ["public", "private"], True)
 
+        self.orderly_initial_source = None
+        self.orderly_initial_url = None
+        if "initial" in dat["orderly"] and dat["orderly"]["initial"]:
+            self.orderly_initial_source = config_enum(
+                dat, ["orderly", "initial", "source"], ["demo", "clone"])
+            if self.orderly_initial_source == "clone":
+                self.orderly_initial_url = config_string(
+                    dat, ["orderly", "initial", "url"])
+            elif "url" in dat["orderly"]["initial"]:
+                # I think an error is a bit harsh
+                print("NOTE: Ignoring orderly:initial:url")
+
     def save(self):
         orderly = self.get_container("orderly")
         txt = base64.b64encode(pickle.dumps(self)).decode("utf8")
@@ -330,6 +342,14 @@ def config_dict_strict(data, path, keys, is_optional=False):
             raise ValueError("Expected a string for {}".format(
                 ":".join(path + [k])))
     return d
+
+
+def config_enum(data, path, values, is_optional=False):
+    value = config_string(data, path, is_optional)
+    if value not in values:
+        raise ValueError("Expected one of [{}] for {}".format(
+            ", ".join(values), ":".join(path)))
+    return value
 
 
 def config_image_reference(dat, path, name="name"):

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -38,8 +38,7 @@ def start(path, extra=None, options=None, pull_images=False):
 def orderly_init(cfg, docker_client):
     container = orderly_container(cfg, docker_client)
     orderly_write_ssh_keys(cfg.orderly_ssh, container)
-    if not orderly_is_initialised(container):
-        orderly_init_demo(container)
+    orderly_initial_data(cfg, container)
     orderly_check_schema(container)
     orderly_write_env(cfg.orderly_env, container)
     orderly_start(container)
@@ -57,6 +56,16 @@ def orderly_container(cfg, docker_client):
     return container
 
 
+def orderly_initial_data(cfg, container):
+    if not orderly_is_initialised(container):
+        if cfg.orderly_initial_source == "demo":
+            orderly_init_demo(container)
+        elif cfg.orderly_initial_source == "clone":
+            orderly_init_clone(container, cfg.orderly_initial_url)
+        else:
+            raise Exception("Orderly volume not initialised")
+
+
 def orderly_write_env(env, container):
     if not env:
         return
@@ -69,6 +78,12 @@ def orderly_write_env(env, container):
 def orderly_init_demo(container):
     print("Initialising orderly with demo data")
     args = ["Rscript", "-e", "orderly:::create_orderly_demo('/orderly')"]
+    exec_safely(container, args)
+
+
+def orderly_init_clone(container, url):
+    print("Initialising orderly by cloning")
+    args = ["git", "clone", url, "/orderly"]
     exec_safely(container, args)
 
 

--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -57,7 +57,9 @@ def orderly_container(cfg, docker_client):
 
 
 def orderly_initial_data(cfg, container):
-    if not orderly_is_initialised(container):
+    if orderly_is_initialised(container):
+        print("orderly volume already contains data - not initialising")
+    else:
         if cfg.orderly_initial_source == "demo":
             orderly_init_demo(container)
         elif cfg.orderly_initial_source == "clone":

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -218,6 +218,13 @@ def test_combine():
         {"a": {"x": 3}, "b": 2}
 
 
+def combine_can_replace_dict():
+    base = {"a": {"c": {"d": "x"}}, "b": "y"}
+    options = {"a": {"c": None}}
+    combine(base, options)
+    assert base["a"]["c"] == None
+
+
 def test_read_and_extra():
     with tempfile.TemporaryDirectory() as p:
         shutil.copy("config/basic/orderly-web.yml", p)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -106,6 +106,7 @@ def test_example_config():
     assert cfg.orderly_initial_source is "demo"
     assert cfg.orderly_initial_url is None
 
+
 def test_config_custom_styles():
     path = "config/customcss"
     cfg = build_config(path)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -222,7 +222,7 @@ def combine_can_replace_dict():
     base = {"a": {"c": {"d": "x"}}, "b": "y"}
     options = {"a": {"c": None}}
     combine(base, options)
-    assert base["a"]["c"] == None
+    assert base["a"]["c"] is None
 
 
 def test_read_and_extra():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -103,8 +103,9 @@ def test_example_config():
     assert cfg.proxy_ssl_self_signed
     assert str(cfg.images["proxy"]) == "vimc/orderly-web-proxy:master"
 
-    assert cfg.orderly_initial_source is "demo"
-    assert cfg.orderly_initial_url is None
+    assert cfg.orderly_initial_source == "clone"
+    assert cfg.orderly_initial_url == \
+        "https://github.com/reside-ic/orderly-example"
 
 
 def test_config_custom_styles():
@@ -325,7 +326,7 @@ def test_can_use_url_for_initial_source():
 def test_initial_clone_requires_url():
     options = {"orderly": {"initial": {"source": "clone"}}}
     with pytest.raises(KeyError, match="orderly:initial:url"):
-        cfg = build_config("config/basic", options=options)
+        cfg = build_config("config/montagu", options=options)
 
 
 def test_initial_demo_ignores_url():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -71,6 +71,17 @@ def test_config_dict_strict_raises_if_not_strings():
         config_dict_strict(dat, ["a", "b"], "c")
 
 
+def test_config_enum_returns_string():
+    assert config_enum(sample_data, ["b", "x"], ["value1", "value2"]) == \
+        "value2"
+
+
+def test_config_enum_raises_if_invalid():
+    with pytest.raises(ValueError,
+                       match=r"Expected one of \[enum1, enum2\] for b:x"):
+        config_enum(sample_data, ["b", "x"], ["enum1", "enum2"])
+
+
 def test_example_config():
     cfg = build_config("config/basic")
     assert cfg.network == "orderly_web_network"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,5 +1,6 @@
 import io
 from contextlib import redirect_stdout
+import pytest
 import urllib
 import time
 import json

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -78,6 +78,13 @@ def test_start_and_stop():
         dat = json.loads(http_get("https://localhost/api/v1"))
         assert dat["status"] == "success"
 
+        # Orderly volume contains only the stripped down example from
+        # the URL, not the whole demo:
+        orderly = cfg.get_container("orderly")
+        src = exec_safely(orderly, ["ls", "/orderly/src"])[1]
+        src_contents = src.decode("UTF-8").strip().split("\n")
+        assert set(src_contents) == set(["README.md", "example"])
+
         # Bring the whole lot down:
         orderly_web.stop(path, kill=True, volumes=True, network=True)
         st = orderly_web.status(path)


### PR DESCRIPTION
This PR makes explicit where the initial data comes from:

* there is a new section in the orderly part of the configuration `initial`
* the existing behaviour of starting with the demo data can be selected, but is no longer the default
* we can clone from a URL - with mrc-334 (#19) merged, this could be a ssh url for a private repo
* the default behaviour is to do nothing, requiring the user to pre-initialise the volume and we error if it is not initialised