### PR TITLE
mrc-393: publish orderly-web-deploy to pypi

### DIFF
--- a/publish.md
+++ b/publish.md
@@ -1,0 +1,37 @@
+## Publishing
+
+The python installer is mysterious and is liable to not reflect your sources if old files are around, even if it _seems_ like things have changed.  Deleting some things first helps:
+
+```
+rm -rf orderly_web.egg-info dist
+```
+
+Build the source distribution for publishing
+
+```
+python3 setup.py sdist
+```
+
+To testing
+
+```
+twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+```
+
+Test the installation
+
+```
+docker run --rm -it --entrypoint bash python
+```
+
+then
+
+```
+pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple orderly-web
+```
+
+Then upload to the main index
+
+```
+twine upload dist/*
+```

--- a/publish.md
+++ b/publish.md
@@ -18,6 +18,8 @@ To testing
 twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 ```
 
+To do this, the version number **must** be incremented over the published versions ([testing](https://test.pypi.org/project/orderly-web/), [main index](https://pypi.org/project/orderly-web/)) - if you forget to increment it the server will reject the upload.
+
 Test the installation
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "Pillow"]
 
 setup(name="orderly_web",
-      version="0.0.2",
+      version="0.0.3",
       description="Deploy scripts for OrderlyWeb",
       long_description=long_description,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,14 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as f:
     long_description = f.read()
 
-with open("requirements.txt") as requirements_txt:
-    requirements = [line for line in requirements_txt]
+requirements = [
+    "docker",
+    "docopt",
+    "hvac",
+    "pytest",
+    "pyyaml",
+    "vault_dev",
+    "Pillow"]
 
 setup(name="orderly_web",
       version="0.0.2",

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,11 @@ from setuptools import setup, find_packages
 with open("README.md", "r") as f:
     long_description = f.read()
 
+with open("requirements.txt") as requirements_txt:
+    requirements = [line for line in requirements_txt]
+
 setup(name="orderly_web",
-      version="0.0.1",
+      version="0.0.2",
       description="Deploy scripts for OrderlyWeb",
       long_description=long_description,
       classifiers=[
@@ -29,10 +32,4 @@ setup(name="orderly_web",
           "vault_dev",
           "pytest"
       ],
-      requires=[
-          "docker",
-          "docopt",
-          "hvac",
-          "yaml",
-          "Pillow"
-      ])
+      install_requires = requirements)


### PR DESCRIPTION
Python packaging continues to be weird.  This seems to work