### PR TITLE
vimc-3310: Update to work with newer python docker package

### DIFF
--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -187,6 +187,3 @@ class docker_client():
     def __enter__(self):
         self.client = docker.client.from_env()
         return self.client
-
-    def __exit__(self, type, value, traceback):
-        self.client.close()

--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -187,3 +187,6 @@ class docker_client():
     def __enter__(self):
         self.client = docker.client.from_env()
         return self.client
+
+    def __exit__(self, type, value, traceback):
+        pass

--- a/orderly_web/docker_helpers.py
+++ b/orderly_web/docker_helpers.py
@@ -33,14 +33,12 @@ def exec_safely(container, args):
 
 def return_logs_and_remove(client, image, args=None, mounts=None):
     try:
-        result = client.containers.run(image,
-                                       args,
-                                       mounts=mounts,
-                                       stderr=True,
-                                       remove=True)
-    except docker.errors.ContainerError as e:
-        result = e.stderr
-    return result.decode("UTF-8")
+        container = client.containers.run(image, args, mounts=mounts,
+                                          detach=True)
+        res = container.wait()
+        return container.logs().decode("UTF-8")
+    finally:
+        container.remove()
 
 
 def stop_and_remove_container(client, name, kill, timeout=10):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "Pillow"]
 
 setup(name="orderly_web",
-      version="0.0.3",
+      version="0.0.4",
       description="Deploy scripts for OrderlyWeb",
       long_description=long_description,
       classifiers=[


### PR DESCRIPTION
This PR adds no features, but makes two small changes to reflect updates to the docker python package.

* The close part of the docker context handler has been removed - this whole thing is no longer needed (after changing test library from nose to pytest) but it'd generate a lot of noise to remove it, and we'll refactor this whole thing to use constellation
* The logs were not all making it out before docker was removing the container in the `return_logs_and_remove` script so I've updated so that we always get all logs, then remove the container