### PR TITLE
vimc-3308: Don't write secrets to orderly volume

### DIFF
--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -86,8 +86,8 @@ def orderly_write_env(env, container):
     if not env:
         return
     print("Writing orderly environment")
-    dest = "/orderly/orderly_envir.yml"
-    txt = "".join(["{}: {}\n".format(str(k), str(v)) for k, v in env.items()])
+    dest = "/root/.Renviron"
+    txt = "".join(["{}={}\n".format(str(k), str(v)) for k, v in env.items()])
     string_into_container(txt, container, dest)
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     "Pillow"]
 
 setup(name="orderly_web",
-      version="0.0.4",
+      version="0.0.5",
       description="Deploy scripts for OrderlyWeb",
       long_description=long_description,
       classifiers=[

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -349,8 +349,8 @@ def test_vault_ssl():
 
         cfg = fetch_config(path)
         container = cfg.get_container("orderly")
-        res = string_from_container(container, "/orderly/orderly_envir.yml")
-        assert "ORDERLY_DB_PASS: s3cret" in res
+        res = string_from_container(container, "/root/.Renviron")
+        assert "ORDERLY_DB_PASS=s3cret" in res
 
         private = string_from_container(container, "/root/.ssh/id_rsa")
         assert private == "private-key-data"
@@ -412,8 +412,8 @@ def test_vault_github_login_with_prompt():
             cfg = fetch_config(path)
             container = cfg.get_container("orderly")
             res = string_from_container(container,
-                                        "/orderly/orderly_envir.yml")
-            assert "ORDERLY_DB_PASS: s3cret" in res
+                                        "/root/.Renviron")
+            assert "ORDERLY_DB_PASS=s3cret" in res
 
             orderly_web.stop(path, kill=True, volumes=True, network=True)
 
@@ -438,8 +438,8 @@ def test_vault_github_login_from_env():
         cfg = fetch_config(path)
         container = cfg.get_container("orderly")
         res = string_from_container(container,
-                                    "/orderly/orderly_envir.yml")
-        assert "ORDERLY_DB_PASS: s3cret" in res
+                                    "/root/.Renviron")
+        assert "ORDERLY_DB_PASS=s3cret" in res
 
         orderly_web.stop(path, kill=True, volumes=True,
                          network=True)
@@ -469,8 +469,8 @@ def test_vault_github_login_with_mount_path():
         cfg = fetch_config(path)
         container = cfg.get_container("orderly")
         res = string_from_container(container,
-                                    "/orderly/orderly_envir.yml")
-        assert "ORDERLY_DB_PASS: s3cret" in res
+                                    "/root/.Renviron")
+        assert "ORDERLY_DB_PASS=s3cret" in res
 
         orderly_web.stop(path, kill=True, volumes=True,
                          network=True)


### PR DESCRIPTION
This PR will update the location of the secrets and configuration written to support orderly.

Previously these were written to `/orderly/orderly_envir.yml`, which is the recommended location for human users.  However, this means that the production configuration is backed up and restored onto science when montagu is deployed, leaving orderly in an incompatible state until orderly-web is deployed!

With the changes here, the environment variables are written to `/root/.Renviron` which will be read by R on startup, but not persisted.

When deploying these changes, we should do

```
docker exec orderly_web_orderly rm /orderly/orderly_envir.yml
```

before updating in order to delete the previous configuration.  This only needs to be done once.
