### PR TITLE
Remove branch pin on pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,4 @@ hvac
 pytest
 pyyaml
 vault_dev
-# TODO: Unpin pillow branch
-# Pillow v >7.2 requires python >= 3.6 which we don't currently
-# have available on vagrant VMs
-# see https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4586
-Pillow==7.2
+Pillow

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,7 @@ requirements = [
     "pytest",
     "pyyaml",
     "vault_dev",
-    # TODO: Unpin pillow branch
-    # Pillow v >7.2 requires python >= 3.6 which we don't currently
-    # have available on vagrant VMs
-    # see https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4586
-    "Pillow==7.2"]
+    "Pillow"]
 
 setup(name="orderly_web",
       version="0.0.7",


### PR DESCRIPTION
This reverts https://github.com/vimc/orderly-web-deploy/pull/27/commits/bb57e3366c4dc34f17613f55adb36868e8a4c0f3 which we can do now python 3.8 is available on VMs