### PR TITLE
Fix volume mount location to match default location for redis data

### DIFF
--- a/orderly_web/start.py
+++ b/orderly_web/start.py
@@ -62,7 +62,7 @@ def redis_init(cfg, docker_client):
     print("Creating redis container")
     args = ["--appendonly", "yes"]
     image = str(cfg.images["redis"])
-    mounts = [docker.types.Mount("/redis-data", cfg.volumes["redis"])]
+    mounts = [docker.types.Mount("/data", cfg.volumes["redis"])]
     container = docker_client.containers.run(
         image, args, mounts=mounts, network="none",
         name=cfg.containers["redis"], detach=True)


### PR DESCRIPTION
I think we have been mounting this at the wrong location for a while. This means that on redeploy redis data is being wiped so we cannot see status from a workflow previously run.

From redis docker container docs https://hub.docker.com/_/redis

"If persistence is enabled, data is stored in the VOLUME /data, which can be used with --volumes-from some-volume-container or -v /docker/host/dir:/data"

You can see this on any orderly deployment, the redis data is being saved to `/data` but we are mounting at `/redis-data`