### PR TITLE
mrc-3936 add outpack migration tool

### DIFF
--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -56,6 +56,7 @@ network: orderly_web_network
 ## css: stores compiled css for the web app (only needed if custom sass variables
 ## are given as sass_variables in web section below)
 ## documents: stores static documentation available through the web app
+## outpack (optional): stores migrated outpack metadata. must exist if outpack config is set below.
 ##
 ## (More volumes are anticipated as the tool develops)
 volumes:
@@ -64,6 +65,14 @@ volumes:
   css: orderly_web_css
   documents: orderly_web_documents
   redis: orderly_web_redis_data
+  outpack: orderly_web_outpack
+
+# Optional: to migrate the underlying orderly metadata to outpack metadata
+outpack:
+  migrate:
+    repo: mrcide
+    name: outpack.orderly
+    tag: main
 
 ## Redis configuration
 redis:
@@ -173,6 +182,7 @@ web:
   ## Optional custom logo image, any valid image format. Should be a
   ## file path relative to the config file.
   logo: my-test-logo.png
+
 
 # Optional: to notify a Slack channel during deployment, provide a webhook url
 slack:

--- a/config/montagu/orderly-web.yml
+++ b/config/montagu/orderly-web.yml
@@ -17,6 +17,14 @@ volumes:
   orderly: orderly_web_volume
   proxy_logs: orderly_web_proxy_logs
   redis: orderly_web_redis_data
+  outpack: orderly_web_outpack
+
+# Optional: to migrate the underlying orderly metadata to outpack metadata
+outpack:
+  migrate:
+    repo: mrcide
+    name: outpack.orderly
+    tag: main
 
 ## Redis configuration
 redis:

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -180,7 +180,7 @@ class OrderlyWebConfig:
         self.outpack_enabled = "outpack" in dat
         if self.outpack_enabled:
             self.volumes["outpack"] = config.config_string(dat, ["volumes",
-                                                             "outpack"])
+                                                                 "outpack"])
             self.outpack_repo = config.config_string(
                 dat, ["outpack", "migrate", "repo"])
             self.outpack_migrate_name = config.config_string(

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -112,13 +112,6 @@ class OrderlyWebConfig:
 
         self.container_prefix = config.config_string(dat, ["container_prefix"])
 
-        self.containers = {
-            "redis": "redis",
-            "orderly": "orderly",
-            "orderly_worker": "orderly_worker",
-            "web": "web"
-        }
-
         self.workers = config.config_integer(
             self.data, ["orderly", "workers"], is_optional=True, default=1)
 
@@ -167,6 +160,13 @@ class OrderlyWebConfig:
         self.migrate_ref = constellation.ImageReference(
             self.web_repo, self.migrate_name, self.web_tag)
 
+        self.containers = {
+            "redis": "redis",
+            "orderly": "orderly",
+            "orderly_worker": "orderly_worker",
+            "web": "web"
+        }
+
         self.images = {
             "redis": self.redis_ref,
             "orderly": self.orderly_ref,
@@ -175,6 +175,23 @@ class OrderlyWebConfig:
             "admin": self.admin_ref,
             "migrate": self.migrate_ref
         }
+
+        # 7. Outpack
+        self.outpack_enabled = "outpack" in dat
+        if self.outpack_enabled:
+            self.volumes["outpack"] = config.config_string(dat, ["volumes",
+                                                             "outpack"])
+            self.outpack_repo = config.config_string(
+                dat, ["outpack", "migrate", "repo"])
+            self.outpack_migrate_name = config.config_string(
+                dat, ["outpack", "migrate", "name"])
+            self.outpack_migrate_tag = config.config_string(
+                dat, ["outpack", "migrate", "tag"])
+            self.outpack_migrate_ref = constellation.ImageReference(
+                self.outpack_repo, self.outpack_migrate_name,
+                self.outpack_migrate_tag)
+            self.containers["outpack_migrate"] = "outpack_migrate"
+            self.images["outpack_migrate"] = self.outpack_migrate_ref
 
         self.non_constellation_images = {
             "admin": self.admin_ref,

--- a/orderly_web/constellation.py
+++ b/orderly_web/constellation.py
@@ -21,10 +21,24 @@ def orderly_constellation(cfg):
         proxy = proxy_container(cfg, web)
         containers.append(proxy)
 
+    if cfg.outpack_enabled:
+        outpack_migrate = outpack_migrate_container(cfg)
+        containers.append(outpack_migrate)
+
     obj = constellation.Constellation("orderly-web", cfg.container_prefix,
                                       containers, cfg.network, cfg.volumes,
                                       data=cfg, vault_config=cfg.vault)
     return obj
+
+
+def outpack_migrate_container(cfg):
+    name = cfg.containers["outpack_migrate"]
+    mounts = [constellation.ConstellationMount("outpack", "/outpack"),
+              constellation.ConstellationMount("orderly", "/orderly")]
+    args = ["/orderly", "/outpack", "--minutes=5"]
+    outpack_migrate = constellation.ConstellationContainer(
+        name, cfg.outpack_migrate_ref, mounts=mounts, args=args)
+    return outpack_migrate
 
 
 def redis_container(cfg):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -36,7 +36,7 @@ def test_example_config():
     assert cfg.images["orderly_worker"].name == "orderly.server"
     assert cfg.images["orderly_worker"].tag == "master"
     assert str(cfg.images["orderly_worker"]) == \
-        "vimc/orderly.server:master"
+           "vimc/orderly.server:master"
     assert cfg.web_dev_mode
     assert cfg.web_port == 8888
     assert cfg.web_name == "OrderlyWeb"
@@ -60,10 +60,10 @@ def test_example_config():
 
     assert cfg.orderly_initial_source == "clone"
     assert cfg.orderly_initial_url == \
-        "https://github.com/reside-ic/orderly-example"
+           "https://github.com/reside-ic/orderly-example"
 
     assert cfg.slack_webhook_url == \
-        "https://hooks.slack.com/services/T000/B000/XXXX"
+           "https://hooks.slack.com/services/T000/B000/XXXX"
 
 
 def test_documents_volume_inclusion():
@@ -255,16 +255,16 @@ def test_initial_demo_ignores_url():
 
 def test_outpack_volume_required_if_enabled():
     options = {"outpack": {"migrate": {"repo": "mrcide",
-                                "name": "outpack.orderly",
-                                "tag": "main"}}}
+                                       "name": "outpack.orderly",
+                                       "tag": "main"}}}
     with pytest.raises(KeyError, match="volumes:outpack"):
         cfg = build_config("config/basic", options=options)
 
 
 def test_outpack_config():
     options = {"outpack": {"migrate": {"repo": "mrcide",
-                                "name": "outpack.orderly",
-                                "tag": "main"}},
+                                       "name": "outpack.orderly",
+                                       "tag": "main"}},
                "volumes": {"outpack": "outpack_vol"}}
     cfg = build_config("config/basic", options=options)
     assert cfg.outpack_migrate_ref is not None

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -253,6 +253,31 @@ def test_initial_demo_ignores_url():
     assert "NOTE: Ignoring orderly:initial:url" in out
 
 
+def test_outpack_volume_required_if_enabled():
+    options = {"outpack": {"migrate": {"repo": "mrcide",
+                                "name": "outpack.orderly",
+                                "tag": "main"}}}
+    with pytest.raises(KeyError, match="volumes:outpack"):
+        cfg = build_config("config/basic", options=options)
+
+
+def test_outpack_config():
+    options = {"outpack": {"migrate": {"repo": "mrcide",
+                                "name": "outpack.orderly",
+                                "tag": "main"}},
+               "volumes": {"outpack": "outpack_vol"}}
+    cfg = build_config("config/basic", options=options)
+    assert cfg.outpack_migrate_ref is not None
+    assert cfg.containers["outpack_migrate"] == "outpack_migrate"
+    assert cfg.volumes["outpack"] == "outpack_vol"
+    assert cfg.outpack_enabled is True
+
+
+def test_outpack_disabled_if_no_config():
+    cfg = build_config("config/basic")
+    assert cfg.outpack_enabled is False
+
+
 def read_file(path):
     with open(path, "r") as f:
         return f.read()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -133,7 +133,7 @@ def test_start_with_custom_styles():
         logo = docker_util.bytes_from_container(web, expected_destination)
         assert len(logo) > 0
         res = requests.get("http://localhost:8888")
-        assert """<img src="http://localhost:8888/img/logo/my-test-logo.png"""\
+        assert """<img src="http://localhost:8888/img/logo/my-test-logo.png""" \
                in res.text
         res = requests.get("http://localhost:8888/img/logo/my-test-logo.png")
         assert res.status_code == 200
@@ -373,10 +373,10 @@ def test_vault_github_login_with_mount_path():
         path = "config/vault"
         vault_addr = "http://localhost:{}".format(s.port)
         options = {"vault":
-                   {"addr": vault_addr,
-                    "auth":
-                    {"method": "github",
-                     "args": {"mount_point": "github-custom"}}}}
+                       {"addr": vault_addr,
+                        "auth":
+                            {"method": "github",
+                             "args": {"mount_point": "github-custom"}}}}
 
         orderly_web.start(path, options=options)
 
@@ -426,8 +426,8 @@ def test_can_start_with_prepared_volume():
             res = orderly_web.start(path, options=options)
         assert res
         out = f.getvalue()
-        expected = '[orderly] orderly volume already contains data - not '\
-            'initialising'
+        expected = '[orderly] orderly volume already contains data - not ' \
+                   'initialising'
         assert expected in out.splitlines()
     finally:
         orderly_web.stop(path, kill=True, volumes=True, network=True)
@@ -436,8 +436,8 @@ def test_can_start_with_prepared_volume():
 def test_can_start_with_outpack():
     path = "config/basic"
     options = {"outpack": {"migrate": {"repo": "mrcide",
-                                "name": "outpack.orderly",
-                                "tag": "main"}},
+                                       "name": "outpack.orderly",
+                                       "tag": "main"}},
                "volumes": {"outpack": "outpack_vol"}}
     cfg = build_config(path, options=options)
     try:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -433,6 +433,21 @@ def test_can_start_with_prepared_volume():
         orderly_web.stop(path, kill=True, volumes=True, network=True)
 
 
+def test_can_start_with_outpack():
+    path = "config/basic"
+    options = {"outpack": {"migrate": {"repo": "mrcide",
+                                "name": "outpack.orderly",
+                                "tag": "main"}},
+               "volumes": {"outpack": "outpack_vol"}}
+    cfg = build_config(path, options=options)
+    try:
+        orderly_web.start(path, options=options)
+        assert docker_util.container_exists("orderly_web_outpack_migrate")
+        assert docker_util.volume_exists("outpack")
+    finally:
+        orderly_web.stop(path, kill=True, volumes=True, network=True)
+
+
 def test_notifies_slack_on_success():
     with patch.object(Notifier, 'post',
                       return_value=None) as mock_notify:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -443,7 +443,7 @@ def test_can_start_with_outpack():
     try:
         orderly_web.start(path, options=options)
         assert docker_util.container_exists("orderly_web_outpack_migrate")
-        assert docker_util.volume_exists("outpack")
+        assert docker_util.volume_exists("outpack_vol")
     finally:
         orderly_web.stop(path, kill=True, volumes=True, network=True)
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -133,7 +133,7 @@ def test_start_with_custom_styles():
         logo = docker_util.bytes_from_container(web, expected_destination)
         assert len(logo) > 0
         res = requests.get("http://localhost:8888")
-        assert """<img src="http://localhost:8888/img/logo/my-test-logo.png""" \
+        assert """<img src="http://localhost:8888/img/logo/my-test-logo.png"""\
                in res.text
         res = requests.get("http://localhost:8888/img/logo/my-test-logo.png")
         assert res.status_code == 200
@@ -372,11 +372,10 @@ def test_vault_github_login_with_mount_path():
 
         path = "config/vault"
         vault_addr = "http://localhost:{}".format(s.port)
-        options = {"vault":
-                       {"addr": vault_addr,
-                        "auth":
-                            {"method": "github",
-                             "args": {"mount_point": "github-custom"}}}}
+        options = {"vault": {"addr": vault_addr,
+                             "auth":
+                                 {"method": "github",
+                                  "args": {"mount_point": "github-custom"}}}}
 
         orderly_web.start(path, options=options)
 


### PR DESCRIPTION
This just adds the tool for migrating `orderly` to `outpack` metadata. Further PR coming for adding `outpack_server` as well.