### PR TITLE
remove underscores from container names

### DIFF
--- a/config/basic/orderly-web.yml
+++ b/config/basic/orderly-web.yml
@@ -1,5 +1,5 @@
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
-container_prefix: orderly_web
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/config/breaking/orderly-web.yml
+++ b/config/breaking/orderly-web.yml
@@ -1,4 +1,4 @@
-container_prefix: orderly_web
+container_prefix: orderly-web
 
 network: orderly_web_network
 

--- a/config/complete/orderly-web.yml
+++ b/config/complete/orderly-web.yml
@@ -32,7 +32,7 @@ vault:
     args:
       token: ~
 
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
 ##
 ## This is an important configuration option because it cannot be
 ## overridden by a patch file or by passing options in.
@@ -41,7 +41,7 @@ vault:
 ## OrderlyWeb, then change the prefix, then start it back up.
 ## Otherwise OrderlyWeb will not take down the required containers
 ## before starting back up.
-container_prefix: orderly_web
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/config/customcss/orderly-web.yml
+++ b/config/customcss/orderly-web.yml
@@ -1,5 +1,5 @@
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
-container_prefix: orderly_web
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/config/montagu/orderly-web.yml
+++ b/config/montagu/orderly-web.yml
@@ -1,5 +1,5 @@
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
-container_prefix: orderly_web
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/config/noproxy/orderly-web.yml
+++ b/config/noproxy/orderly-web.yml
@@ -1,5 +1,5 @@
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
-container_prefix: orderly_web
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/config/vault/orderly-web.yml
+++ b/config/vault/orderly-web.yml
@@ -14,8 +14,8 @@ vault:
     ##     azure, github, gcp, kubernetes, ldap, mfa, okta
     method: github
 
-## Prefix for container names; we'll use {container_prefix}_(orderly,web)
-container_prefix: orderly_web
+## Prefix for container names; we'll use {container_prefix}-(orderly,web)
+container_prefix: orderly-web
 
 ## The name of the docker network that containers will be attached to.
 ## If you want to proxy OrderlyWeb to the host, you will need to

--- a/orderly_web/config.py
+++ b/orderly_web/config.py
@@ -69,7 +69,7 @@ class OrderlyWebConfigBase:
         self.containers = {
             "redis": "redis",
             "orderly": "orderly",
-            "orderly_worker": "orderly_worker",
+            "orderly-worker": "orderly-worker",
             "web": "web"
         }
 
@@ -85,7 +85,7 @@ class OrderlyWebConfigBase:
             with docker_client() as cl:
                 name = self.containers[PATH_CONFIG["container"]]
                 container = cl.containers.get(
-                    "{}_{}".format(self.container_prefix, name))
+                    "{}-{}".format(self.container_prefix, name))
         except docker.errors.NotFound:
             return None
         path = PATH_CONFIG["path"]
@@ -163,14 +163,14 @@ class OrderlyWebConfig:
         self.containers = {
             "redis": "redis",
             "orderly": "orderly",
-            "orderly_worker": "orderly_worker",
+            "orderly-worker": "orderly-worker",
             "web": "web"
         }
 
         self.images = {
             "redis": self.redis_ref,
             "orderly": self.orderly_ref,
-            "orderly_worker": self.orderly_worker_ref,
+            "orderly-worker": self.orderly_worker_ref,
             "web": self.web_ref,
             "admin": self.admin_ref,
             "migrate": self.migrate_ref
@@ -201,10 +201,10 @@ class OrderlyWebConfig:
                 self.outpack_migrate_repo, self.outpack_migrate_name,
                 self.outpack_migrate_tag)
 
-            self.containers["outpack_server"] = "outpack_server"
-            self.images["outpack_server"] = self.outpack_ref
-            self.containers["outpack_migrate"] = "outpack_migrate"
-            self.images["outpack_migrate"] = self.outpack_migrate_ref
+            self.containers["outpack-server"] = "outpack-server"
+            self.images["outpack-server"] = self.outpack_ref
+            self.containers["outpack-migrate"] = "outpack-migrate"
+            self.images["outpack-migrate"] = self.outpack_migrate_ref
 
         self.non_constellation_images = {
             "admin": self.admin_ref,
@@ -346,7 +346,7 @@ class OrderlyWebConfig:
 
     def get_container(self, name):
         with docker_client() as cl:
-            return cl.containers.get("{}_{}".format(self.container_prefix,
+            return cl.containers.get("{}-{}".format(self.container_prefix,
                                                     self.containers[name]))
 
     def resolve_secrets(self):

--- a/orderly_web/constellation.py
+++ b/orderly_web/constellation.py
@@ -265,7 +265,7 @@ def web_container_config(container, cfg):
         opts["auth.github_key"] = cfg.web_auth_github_app["id"]
         opts["auth.github_secret"] = cfg.web_auth_github_app["secret"]
     if cfg.outpack_enabled:
-        outpack_container = cfg.containers["outpack_server"]
+        outpack_container = cfg.containers["outpack-server"]
         opts["outpack.server"] = \
             "http://{}-{}:8000".format(cfg.container_prefix,
                                        outpack_container)

--- a/orderly_web/constellation.py
+++ b/orderly_web/constellation.py
@@ -34,7 +34,7 @@ def orderly_constellation(cfg):
 
 
 def outpack_server_container(cfg):
-    name = cfg.containers["outpack_server"]
+    name = cfg.containers["outpack-server"]
     mounts = [constellation.ConstellationMount("outpack", "/outpack")]
     outpack_server = constellation.ConstellationContainer(
         name, cfg.outpack_ref, mounts=mounts)
@@ -42,7 +42,7 @@ def outpack_server_container(cfg):
 
 
 def outpack_migrate_container(cfg):
-    name = cfg.containers["outpack_migrate"]
+    name = cfg.containers["outpack-migrate"]
     mounts = [constellation.ConstellationMount("outpack", "/outpack"),
               constellation.ConstellationMount("orderly", "/orderly")]
     args = ["/orderly", "/outpack", "--minutes=5"]
@@ -156,7 +156,7 @@ def orderly_start(container):
 
 
 def worker_container(cfg, redis_container):
-    worker_name = cfg.containers["orderly_worker"]
+    worker_name = cfg.containers["orderly-worker"]
     worker_args = ["--go-signal", "/go_signal"]
     worker_mounts = [constellation.ConstellationMount("orderly", "/orderly")]
     worker_entrypoint = "/usr/local/bin/orderly_worker"
@@ -253,7 +253,7 @@ def web_container_config(container, cfg):
             "auth.github_team": cfg.web_auth_github_team or "",
             "auth.fine_grained": str(cfg.web_auth_fine_grained).lower(),
             "auth.provider": "montagu" if cfg.web_auth_montagu else "github",
-            "orderly.server": "http://{}_{}:8321".format(cfg.container_prefix,
+            "orderly.server": "http://{}-{}:8321".format(cfg.container_prefix,
                                                          orderly_container)
             }
     if cfg.logo_name is not None:
@@ -267,7 +267,7 @@ def web_container_config(container, cfg):
     if cfg.outpack_enabled:
         outpack_container = cfg.containers["outpack_server"]
         opts["outpack.server"] = \
-            "http://{}_{}:8000".format(cfg.container_prefix,
+            "http://{}-{}:8000".format(cfg.container_prefix,
                                        outpack_container)
     txt = "".join(["{}={}\n".format(k, v) for k, v in opts.items()])
     docker_util.exec_safely(container, ["mkdir", "-p", "/etc/orderly/web"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.12
+constellation==1.0.0
 docker
 docopt
 hvac

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,7 +16,7 @@ def test_cli_basic_usage():
 
     assert "Network:\n    - orderly_web_network: created" in out
     assert "Volumes:\n    - redis (orderly_web_redis_data): created" in out
-    assert "- web (orderly_web_web): running" in out
+    assert "- web (orderly-web-web): running" in out
 
     stop_args = ["stop", path, "--kill", "--volumes", "--network"]
     orderly_web.cli.main(stop_args)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -18,10 +18,10 @@ def test_example_config():
     assert cfg.network == "orderly_web_network"
     assert cfg.volumes["orderly"] == "orderly_web_volume"
     assert cfg.volumes["redis"] == "orderly_web_redis_data"
-    assert cfg.container_prefix == "orderly_web"
+    assert cfg.container_prefix == "orderly-web"
     assert cfg.containers["redis"] == "redis"
     assert cfg.containers["orderly"] == "orderly"
-    assert cfg.containers["orderly_worker"] == "orderly_worker"
+    assert cfg.containers["orderly-worker"] == "orderly-worker"
     assert cfg.containers["web"] == "web"
 
     assert cfg.workers == 1
@@ -32,10 +32,10 @@ def test_example_config():
     assert cfg.images["orderly"].name == "orderly.server"
     assert cfg.images["orderly"].tag == "master"
     assert str(cfg.images["orderly"]) == "vimc/orderly.server:master"
-    assert cfg.images["orderly_worker"].repo == "vimc"
-    assert cfg.images["orderly_worker"].name == "orderly.server"
-    assert cfg.images["orderly_worker"].tag == "master"
-    assert str(cfg.images["orderly_worker"]) == \
+    assert cfg.images["orderly-worker"].repo == "vimc"
+    assert cfg.images["orderly-worker"].name == "orderly.server"
+    assert cfg.images["orderly-worker"].tag == "master"
+    assert str(cfg.images["orderly-worker"]) == \
            "vimc/orderly.server:master"
     assert cfg.web_dev_mode
     assert cfg.web_port == 8888
@@ -273,9 +273,9 @@ def test_outpack_config():
                "volumes": {"outpack": "outpack_vol"}}
     cfg = build_config("config/basic", options=options)
     assert cfg.outpack_migrate_ref is not None
-    assert cfg.containers["outpack_migrate"] == "outpack_migrate"
+    assert cfg.containers["outpack-migrate"] == "outpack-migrate"
     assert cfg.outpack_ref is not None
-    assert cfg.containers["outpack_server"] == "outpack_server"
+    assert cfg.containers["outpack-server"] == "outpack-server"
     assert cfg.volumes["outpack"] == "outpack_vol"
     assert cfg.outpack_enabled is True
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -38,15 +38,15 @@ def test_start_and_stop():
         assert docker_util.volume_exists(cfg.volumes["orderly"])
         assert docker_util.volume_exists(cfg.volumes["documents"])
         assert docker_util.volume_exists(cfg.volumes["redis"])
-        assert docker_util.container_exists("orderly_web_web")
-        assert docker_util.container_exists("orderly_web_orderly")
-        assert docker_util.container_exists("orderly_web_proxy")
-        assert docker_util.container_exists("orderly_web_redis")
+        assert docker_util.container_exists("orderly-web-web")
+        assert docker_util.container_exists("orderly-web-orderly")
+        assert docker_util.container_exists("orderly-web-proxy")
+        assert docker_util.container_exists("orderly-web-redis")
 
         names = []
         for container in containers:
             names.append(container.name)
-        assert any(re.match(r"orderly_web_orderly_worker_\w+", name)
+        assert any(re.match(r"orderly-web-orderly-worker-\w+", name)
                    for name in names)
 
         web = cfg.get_container("web")
@@ -56,7 +56,7 @@ def test_start_and_stop():
         assert "app.url=https://localhost" in web_config
         assert "auth.github_key=notarealid" in web_config
         assert "auth.github_secret=notarealsecret" in web_config
-        assert "orderly.server=http://orderly_web_orderly:8321" in web_config
+        assert "orderly.server=http://orderly-web-orderly:8321" in web_config
 
         # Trivial check that the proxy container works too:
         proxy = cfg.get_container("proxy")
@@ -82,10 +82,10 @@ def test_start_and_stop():
         assert not docker_util.volume_exists(cfg.volumes["orderly"])
         assert not docker_util.volume_exists(cfg.volumes["documents"])
         assert not docker_util.volume_exists(cfg.volumes["redis"])
-        assert not docker_util.container_exists("orderly_web_web")
-        assert not docker_util.container_exists("orderly_web_orderly")
-        assert not docker_util.container_exists("orderly_web_proxy")
-        assert not docker_util.container_exists("orderly_web_redis")
+        assert not docker_util.container_exists("orderly-web-web")
+        assert not docker_util.container_exists("orderly-web-orderly")
+        assert not docker_util.container_exists("orderly-web-proxy")
+        assert not docker_util.container_exists("orderly-web-redis")
     finally:
         orderly_web.stop(path, kill=True, volumes=True, network=True)
 
@@ -101,14 +101,14 @@ def test_start_with_custom_styles():
 
         assert docker_util.network_exists(cfg.network)
         assert docker_util.volume_exists(cfg.volumes["css"])
-        assert docker_util.container_exists("orderly_web_web")
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-web")
+        assert docker_util.container_exists("orderly-web-orderly")
         assert not docker_util.volume_exists("documents")
 
         # check that the style volume is really mounted
         cl = docker.client.from_env()
         api_client = cl.api
-        details = api_client.inspect_container("orderly_web_web")
+        details = api_client.inspect_container("orderly-web-web")
         assert len(details['Mounts']) == 2
         css_volume = [v for v in details['Mounts']
                       if v['Type'] == "volume" and
@@ -159,10 +159,10 @@ def test_stop_broken_orderly_web():
 
         assert stop_failed
 
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-orderly")
     finally:
         orderly_web.stop(path, force=True, network=True, volumes=True)
-        assert not docker_util.container_exists("orderly_web_orderly")
+        assert not docker_util.container_exists("orderly-web-orderly")
 
 
 def test_stop_broken_orderly_web_with_option():
@@ -177,13 +177,13 @@ def test_stop_broken_orderly_web_with_option():
 
         assert start_failed
 
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-orderly")
         assert docker_util.network_exists("ow_broken_test")
 
     finally:
         orderly_web.stop(path, force=True, network=True, volumes=True,
                          options=options)
-    assert not docker_util.container_exists("orderly_web_orderly")
+    assert not docker_util.container_exists("orderly-web-orderly")
     assert not docker_util.network_exists("ow_broken_test")
 
 
@@ -198,12 +198,12 @@ def test_stop_broken_orderly_web_with_extra():
             start_failed = True
 
         assert start_failed
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-orderly")
         assert docker_util.network_exists("ow_broken_extra_test")
     finally:
         orderly_web.stop(path, force=True, network=True, volumes=True,
                          extra=extra)
-        assert not docker_util.container_exists("orderly_web_orderly")
+        assert not docker_util.container_exists("orderly-web-orderly")
         assert not docker_util.network_exists("ow_broken_extra_test")
 
 
@@ -216,8 +216,8 @@ def test_start_with_montagu_config():
         cfg = fetch_config(path)
 
         assert docker_util.network_exists(cfg.network)
-        assert docker_util.container_exists("orderly_web_web")
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-web")
+        assert docker_util.container_exists("orderly-web-orderly")
 
         web = cfg.get_container("web")
         web_config = docker_util.string_from_container(
@@ -296,8 +296,8 @@ def test_without_github_app_for_montagu():
     assert res
     cfg = fetch_config(path)
     assert docker_util.network_exists(cfg.network)
-    assert docker_util.container_exists("orderly_web_web")
-    assert docker_util.container_exists("orderly_web_orderly")
+    assert docker_util.container_exists("orderly-web-web")
+    assert docker_util.container_exists("orderly-web-orderly")
 
     orderly_web.stop(path, kill=True, volumes=True, network=True)
 
@@ -441,13 +441,13 @@ def test_can_start_with_outpack():
     cfg = build_config(path, options=options)
     try:
         orderly_web.start(path, options=options)
-        assert docker_util.container_exists("orderly_web_outpack_migrate")
-        assert docker_util.container_exists("orderly_web_outpack_server")
+        assert docker_util.container_exists("orderly-web-outpack-migrate")
+        assert docker_util.container_exists("orderly-web-outpack-server")
         assert docker_util.volume_exists("outpack_vol")
         web = cfg.get_container("web")
         web_config = docker_util.string_from_container(
             web, "/etc/orderly/web/config.properties").split("\n")
-        expected = "outpack.server=http://orderly_web_outpack_server:8000"
+        expected = "outpack.server=http://orderly-web-outpack-server:8000"
         assert expected in web_config
     finally:
         orderly_web.stop(path, kill=True, volumes=True, network=True)
@@ -487,10 +487,10 @@ def test_start_and_stop_multiple_workers():
     try:
         res = orderly_web.start(path, options=options)
         assert res
-        assert docker_util.container_exists("orderly_web_web")
-        assert docker_util.container_exists("orderly_web_orderly")
-        assert docker_util.container_exists("orderly_web_proxy")
-        assert docker_util.container_exists("orderly_web_redis")
+        assert docker_util.container_exists("orderly-web-web")
+        assert docker_util.container_exists("orderly-web-orderly")
+        assert docker_util.container_exists("orderly-web-proxy")
+        assert docker_util.container_exists("orderly-web-redis")
 
         cl = docker.client.from_env()
         containers = cl.containers.list()
@@ -499,7 +499,7 @@ def test_start_and_stop_multiple_workers():
         for container in containers:
             names.append(container.name)
         workers = list(filter(lambda name: re.match(
-            r"orderly_web_orderly_worker_\w+", name), names))
+            r"orderly-web-orderly-worker-\w+", name), names))
         assert len(workers) == 2
 
         # Bring the whole lot down:
@@ -515,10 +515,10 @@ def test_wait_for_redis_exists():
     try:
         res = orderly_web.start(path)
         assert res
-        assert docker_util.container_exists("orderly_web_web")
-        assert docker_util.container_exists("orderly_web_orderly")
-        assert docker_util.container_exists("orderly_web_proxy")
-        assert docker_util.container_exists("orderly_web_redis")
+        assert docker_util.container_exists("orderly-web-web")
+        assert docker_util.container_exists("orderly-web-orderly")
+        assert docker_util.container_exists("orderly-web-proxy")
+        assert docker_util.container_exists("orderly-web-redis")
 
         cfg = fetch_config(path)
         container = cfg.get_container("redis")
@@ -534,7 +534,7 @@ def test_remote_identity_set():
     try:
         res = orderly_web.start(path)
         assert res
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-orderly")
 
         # Remote identity is set via env var ORDERLY_API_SERVER_IDENTITY
         # This matches config from orderly_config.yml which sets
@@ -553,7 +553,7 @@ def test_orderly_server_not_exposed_to_host():
     try:
         res = orderly_web.start(path)
         assert res
-        assert docker_util.container_exists("orderly_web_orderly")
+        assert docker_util.container_exists("orderly-web-orderly")
 
         try:
             json.loads(http_get("http://localhost:8321/run-metadata"))

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -131,7 +131,7 @@ def test_start_with_custom_styles():
         expected_destination = "/static/public/img/logo/my-test-logo.png"
         logo = docker_util.bytes_from_container(web, expected_destination)
         assert len(logo) > 0
-        res = requests.get("http://localhost:8888")
+        res = http_get("http://localhost:8888")
         assert """<img src="http://localhost:8888/img/logo/my-test-logo.png"""\
                in res.text
         res = requests.get("http://localhost:8888/img/logo/my-test-logo.png")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -133,7 +133,7 @@ def test_start_with_custom_styles():
         assert len(logo) > 0
         res = http_get("http://localhost:8888")
         assert """<img src="http://localhost:8888/img/logo/my-test-logo.png"""\
-               in res.text
+               in res
         res = requests.get("http://localhost:8888/img/logo/my-test-logo.png")
         assert res.status_code == 200
     finally:


### PR DESCRIPTION
This updates the prefix and container names to use hyphens instead of underscores, as per https://github.com/reside-ic/constellation/pull/17

I haven't changed the volume names (or network name) - it's a bit annoying/confusing not to be consistent, but technically these don't present the same issue and since in some cases volumes are persisted I think might be hard to rename...